### PR TITLE
Python3 compatibility

### DIFF
--- a/python/apps/bounds.py
+++ b/python/apps/bounds.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
         if outroot is not None:
             out_file.write( '\\begin{tabular}{ |'+''.join(['l|' for i in range(latex_num_col) ])+' }\n' )
         else:
-            print '\\begin{tabular}{ |'+''.join(['l|' for i in range(latex_num_col) ])+' }'
+            print('\\begin{tabular}{ |'+''.join(['l|' for i in range(latex_num_col) ])+' }')
             
     # print the confidence bounds on the Fisher matrices:
     for num, fish in enumerate(fishers.get_fisher_list()):
@@ -213,7 +213,7 @@ if __name__ == "__main__":
                 table_length = len(print_table)/latex_num_col +1
             print_table = fu.grouper( table_length, print_table,fillvalue='' )
             print_table = [ list(i) for i in print_table]      
-            print_table = map(list, zip(*print_table))
+            print_table = list(map(list, list(zip(*print_table))))
             col_width = [max(len(str(x)) for x in col) for col in zip(*print_table)]
             
             if outroot is not None:
@@ -223,11 +223,11 @@ if __name__ == "__main__":
                 for line in print_table:
                     out_file.write( " " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]\n" )
             else:
-                print '\hline'
-                print '\multicolumn{'+str(latex_num_col)+'}{|c|}{'+fish.name.replace('_',' ')+'} \\\[1mm]'
-                print '\hline'
+                print('\hline')
+                print('\multicolumn{'+str(latex_num_col)+'}{|c|}{'+fish.name.replace('_',' ')+'} \\\[1mm]')
+                print('\hline')
                 for line in print_table:
-                    print " " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]"
+                    print(" " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]")
                 
         else:
             # put on top the labels of the columns:
@@ -245,11 +245,11 @@ if __name__ == "__main__":
             #
             print_table = [parameter_names,fiducial,Bounds_68, Bounds_95, Bounds_99]
             if outroot is not None:
-                out_file.write( ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
+                out_file.write( ''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
                 out_file.write( 'Parameter bounds for the Fisher matrix: '+fish.name+'\n' )
-                out_file.write( ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
+                out_file.write( ''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
                 out_file.write( '\n' )
-                print_table = map(list, zip(*print_table))
+                print_table = list(map(list, list(zip(*print_table))))
                 col_width = [max(len(str(x)) for x in col) for col in zip(*print_table)]
                 # print it to file:
                 for line in print_table:
@@ -258,9 +258,9 @@ if __name__ == "__main__":
             else:
                 # print the table:
                 # header to screen
-                print ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])
-                print 'Parameter bounds for the Fisher matrix: ', fish.name
-                print ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])
+                print(''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)]))
+                print('Parameter bounds for the Fisher matrix: ', fish.name)
+                print(''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)]))
                 fu.print_table( print_table )
         
     # finalize and close file:
@@ -269,8 +269,8 @@ if __name__ == "__main__":
             out_file.write( '\hline\n' )
             out_file.write( '\end{tabular}' )
         else:
-            print '\hline'
-            print '\end{tabular}'
+            print('\hline')
+            print('\end{tabular}')
         
     if outroot is not None:
         out_file.close()    
@@ -278,8 +278,8 @@ if __name__ == "__main__":
     # print some final feedback:
     if not args.quiet:
         if outroot is not None:
-            print 'Done. Saved results in: ', outroot+'.txt'
+            print('Done. Saved results in: ', outroot+'.txt')
         else:
-            print 'Done.'
+            print('Done.')
     # exit without error:
     exit(0)

--- a/python/apps/compare_SN_mocks.py
+++ b/python/apps/compare_SN_mocks.py
@@ -139,15 +139,15 @@ if __name__ == "__main__":
 
     # print to screen number of SN:
     if not args.quiet:
-        for k in xrange(0, number_SN_mock):
-            print 'Total number of SN in '+names[k]+' :', len(data[k][:,1])
-        print
+        for k in range(0, number_SN_mock):
+            print('Total number of SN in '+names[k]+' :', len(data[k][:,1]))
+        print()
     
     # plot SN redshift distribution and luminosity distance:
     ax_1  = plt.subplot(plot_grid[1,0]) # distribution
     ax_2  = plt.subplot(plot_grid[1,1]) # d_L
     # cycle over files:
-    for k in xrange(0, number_SN_mock):
+    for k in range(0, number_SN_mock):
         # grab the x values:
         x_values = data[k][:,1]
         y_values = data[k][:,2]
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     ax_1  = plt.subplot(plot_grid[2,0])
     ax_2  = plt.subplot(plot_grid[2,1])
     # cycle over files:
-    for k in xrange(0, number_SN_mock):
+    for k in range(0, number_SN_mock):
         # grab the x values:
         x_values = data[k][:,1]
         y_values = data[k][:,3]
@@ -192,7 +192,7 @@ if __name__ == "__main__":
     ax_1  = plt.subplot(plot_grid[3,0])
     ax_2  = plt.subplot(plot_grid[3,1])
     # cycle over files:
-    for k in xrange(0, number_SN_mock):
+    for k in range(0, number_SN_mock):
         # grab the x values:
         x_values = data[k][:,1]
         y_values = data[k][:,4]
@@ -211,7 +211,7 @@ if __name__ == "__main__":
 
     # create legend handlers
     leg_handlers = []
-    for k in xrange(0, number_SN_mock):
+    for k in range(0, number_SN_mock):
         leg_handlers.append( mlines.Line2D([], [], color=fc.nice_colors(k)) )
     # create the legend
     legend_anchor =  plot_grid[0,0].get_position(fig)
@@ -227,6 +227,6 @@ if __name__ == "__main__":
     plt.clf()
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot
+        print('Done. Saved results in: ', outroot)
     # exit without error:
     exit(0)

--- a/python/apps/compare_cls_cov.py
+++ b/python/apps/compare_cls_cov.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     else:
         names = args.labels
     # check wether all the cls covariances have the same size:
-    for i in xrange(0, number_cls_cov):
+    for i in range(0, number_cls_cov):
         if ( data[i].shape[1] != data[0].shape[1] ):
             raise ValueError( 'The cls covariance '+names[i]+' does not have the same size as '+names[0] )
     # number of Cls:
@@ -161,8 +161,8 @@ if __name__ == "__main__":
     fig.set_size_inches( x_size, y_size )
     plot_grid = gridspec.GridSpec( num, num, wspace=x_spacing, hspace=y_spacing )
     # loop over th Cls grid:
-    for ind in xrange(1, num+1):
-        for ind2 in xrange(1, ind+1):
+    for ind in range(1, num+1):
+        for ind2 in range(1, ind+1):
     
             ax  = plt.subplot(plot_grid[ind-1,ind2-1])
             col  = ind + num*(ind2-1)
@@ -289,6 +289,6 @@ if __name__ == "__main__":
     plt.clf()
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot
+        print('Done. Saved results in: ', outroot)
     # exit without error:
     exit(0)

--- a/python/apps/compare_fisher_matrices.py
+++ b/python/apps/compare_fisher_matrices.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     
     # some feedback:
     if not args.quiet:
-        print
+        print()
         
     # get the couples of Fisher matrices:
     fisher_names = list(itertools.combinations( fishers.get_fisher_name_list(), 2))
@@ -171,16 +171,16 @@ if __name__ == "__main__":
     # print some warning feedback it it's the case:
     if not args.quiet:
         if len(fisher_names) > 10:
-            print ' WARNING: comparison will result in '+str(len(fisher_names))+' plots.'
-            print ' That is a lot and will take some time...'
-            print
+            print(' WARNING: comparison will result in '+str(len(fisher_names))+' plots.')
+            print(' That is a lot and will take some time...')
+            print()
     
     # cycle over the couples:
     for fisher_couples in fisher_names:
         
         # print some feedback:
         if not args.quiet:
-            print ' Comparing '+fisher_couples[0]+' and '+fisher_couples[1]+': ',
+            print(' Comparing '+fisher_couples[0]+' and '+fisher_couples[1]+': ', end=' ')
         
         # get the names:
         fisher_name_1 = fisher_couples[0]
@@ -194,11 +194,11 @@ if __name__ == "__main__":
         if fisher_1 == fisher_2:
             # print feedback:
             if not args.quiet:
-                print 'equal.'
+                print('equal.')
         else:
             # print feedback:
             if not args.quiet:
-                print 'different. Plotting results.'
+                print('different. Plotting results.')
             
             # make sure that the two matrices have the same parameters:
             fisher_1_paramnames = fisher_1.get_param_names()
@@ -207,7 +207,7 @@ if __name__ == "__main__":
             
             # check if there's parameters left:
             if len(paramnames)==0:
-                print 'the two Fisher matrices do not have common parameters.'
+                print('the two Fisher matrices do not have common parameters.')
                 continue
             
             # now reshuffle:
@@ -325,7 +325,7 @@ if __name__ == "__main__":
             
             # print some final feedback:
             if not args.quiet:
-                print '  Done. Saved results in: ', outroot+fisher_name_1+'_vs_'+fisher_name_2+'.'+output_format
+                print('  Done. Saved results in: ', outroot+fisher_name_1+'_vs_'+fisher_name_2+'.'+output_format)
         
     # exit without error:
     exit(0)

--- a/python/apps/debug_plotter.py
+++ b/python/apps/debug_plotter.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         if args.y_columns is not None:
             data_indexes = args.y_columns
         else:
-            data_indexes = range(0,n_col)    
+            data_indexes = list(range(0,n_col))    
         # remove the x axis:
         try:
             data_indexes.remove( x_index )
@@ -184,9 +184,9 @@ if __name__ == "__main__":
     # print some final feedback:
     if not args.quiet:
         if outroot is not None:
-            print 'Done. Saved results in: ', outroot
+            print('Done. Saved results in: ', outroot)
         else:
-            print 'Done.'
+            print('Done.')
 
     # exit without error:
     exit(0)

--- a/python/apps/full_analysis.py
+++ b/python/apps/full_analysis.py
@@ -62,7 +62,7 @@ import sys
 import os
 import copy
 import itertools as it
-import ConfigParser
+import configparser
 
 # get the path of the application and the CosmicFish library:
 here = os.path.dirname(os.path.abspath(__file__))
@@ -117,12 +117,12 @@ if __name__ == "__main__":
                 if dict1[option] == -1:
                    DebugPrint("skip: %s" % option)
             except:
-                print("exception on %s!" % option)
+                print(("exception on %s!" % option))
                 dict1[option] = None
         return dict1
     
     #initializing and reading the config file
-    Config = ConfigParser.ConfigParser()
+    Config = configparser.ConfigParser()
     Config.read(inifile)
 
     #Reading general options
@@ -135,36 +135,36 @@ if __name__ == "__main__":
 
     #General screen output
     if not args.quiet:
-       print 'GENERAL OPTIONS:'
-       print ' Output root='+outroot
-       print ' Using derived parameters='+str(derived)
-       print ' Eliminate rather than marginalize='+str(eliminate)
-       print ' ---------------------------------'
-       print ' Bounds from these matrices will be computed:'
+       print('GENERAL OPTIONS:')
+       print(' Output root='+outroot)
+       print(' Using derived parameters='+str(derived))
+       print(' Eliminate rather than marginalize='+str(eliminate))
+       print(' ---------------------------------')
+       print(' Bounds from these matrices will be computed:')
        for elem in files:
-           print elem
+           print(elem)
        if sum_fish[0]:
-           print 'Also the combination of these will be computed:'
+           print('Also the combination of these will be computed:')
            for elem in sum_fish:
-               print elem
-       print ' ---------------------------------'
-       print
-       print
+               print(elem)
+       print(' ---------------------------------')
+       print()
+       print()
 
     if not files[0]:
        if not sum_fish[0]:
-          print 'NO MATRICES TO WORK WITH!'
+          print('NO MATRICES TO WORK WITH!')
           exit()
        else:
           files = sum_fish
-          print 'No fishers to plot, using only the combined one'
+          print('No fishers to plot, using only the combined one')
 
 
     #MOD: too much putput here!
     if derived is not False:
        fishers = fpa.CosmicFish_FisherAnalysis(fisher_path=files, with_derived=True)
        if sum_fish[0]:
-          print 'NOT HERE'
+          print('NOT HERE')
           summing = fpa.CosmicFish_FisherAnalysis(fisher_path=sum_fish, with_derived=True)
     else:
        fishers = fpa.CosmicFish_FisherAnalysis(fisher_path=files, with_derived=False)
@@ -193,8 +193,8 @@ if __name__ == "__main__":
     num1D = Config.items( "1Dplot" )
         
     if not args.quiet and len(num1D)>0:
-        print
-        print 'Producing 1D plots:'
+        print()
+        print('Producing 1D plots:')
     for key, params in num1D:
         params = Config.get("1Dplot", key).split(",")
 
@@ -211,17 +211,17 @@ if __name__ == "__main__":
         plotter.export( outroot+'_1Dplot_'+str(key)+'.png' )
         plotter.close_plot()
         if not args.quiet:
-           print ' 1D plots done for parameters '+str(params)
-           print ' Saved results in: ', outroot+'_1Dplot_'+str(key)+'.png'
+           print(' 1D plots done for parameters '+str(params))
+           print(' Saved results in: ', outroot+'_1Dplot_'+str(key)+'.png')
 
     if not args.quiet and len(num1D)>0:
-        print '1D plots done!'
+        print('1D plots done!')
 
     #Producing 2D plots
     num2D = Config.items( "2Dplot" )
     if not args.quiet and len(num2D)>0:
-        print
-        print 'Producing 2D plots:'
+        print()
+        print('Producing 2D plots:')
     for key, params in num2D:
         params = Config.get("2Dplot", key).split(",")
 
@@ -243,17 +243,17 @@ if __name__ == "__main__":
         plotter.export( outroot+'_2Dplot_'+str(key)+'.png' )
         plotter.close_plot()
         if not args.quiet:
-           print ' 2D plots done for parameters '+str(params)
-           print ' Saved results in: ', outroot+'_2Dplot_'+str(key)+'.png'
+           print(' 2D plots done for parameters '+str(params))
+           print(' Saved results in: ', outroot+'_2Dplot_'+str(key)+'.png')
 
     if not args.quiet and len(num2D)>0:
-        print '2D plots done!'
+        print('2D plots done!')
 
     #Producing triangular plots
     numtri = Config.items( "triplot" )
     if not args.quiet and len(numtri)>0:
-        print 
-        print 'Producing triangular plots:'
+        print() 
+        print('Producing triangular plots:')
     for key, params in numtri:
         params = Config.get("triplot", key).split(",")
 
@@ -270,11 +270,11 @@ if __name__ == "__main__":
         plotter.export( outroot+'_triplot_'+str(key)+'.png' )
         plotter.close_plot()
         if not args.quiet:
-           print ' Triangular plots done for parameters '+str(params)
-           print ' Saved results in: ', outroot+'_triplot_'+str(key)+'.png'
+           print(' Triangular plots done for parameters '+str(params))
+           print(' Saved results in: ', outroot+'_triplot_'+str(key)+'.png')
 
     if not args.quiet and len(numtri)>0:
-        print 'Triangular plots done!'
+        print('Triangular plots done!')
 
     #Producing bounds files:
     # get the parameters:
@@ -285,8 +285,8 @@ if __name__ == "__main__":
     if len(numbounds)>0:
     
         if not args.quiet:
-            print
-            print 'Producing bounds:'
+            print()
+            print('Producing bounds:')
     
         # open the file if wanted:
         if outroot is not None:
@@ -330,7 +330,7 @@ if __name__ == "__main__":
                         table_length = len(print_table)/latex_num_col +1
                     print_table = fu.grouper( table_length, print_table,fillvalue='' )
                     print_table = [ list(i) for i in print_table]      
-                    print_table = map(list, zip(*print_table))
+                    print_table = list(map(list, list(zip(*print_table))))
                     col_width = [max(len(str(x)) for x in col) for col in zip(*print_table)]
                     
                     if outroot is not None:
@@ -340,11 +340,11 @@ if __name__ == "__main__":
                         for line in print_table:
                             out_file.write( " " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]\n" )
                     else:
-                        print '\hline'
-                        print '\multicolumn{'+str(latex_num_col)+'}{|c|}{'+fish.name.replace('_',' ')+'} \\\[1mm]'
-                        print '\hline'
+                        print('\hline')
+                        print('\multicolumn{'+str(latex_num_col)+'}{|c|}{'+fish.name.replace('_',' ')+'} \\\[1mm]')
+                        print('\hline')
                         for line in print_table:
-                            print " " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]"
+                            print(" " + " & ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " \\\[1mm]")
                         
                 else:
                     # put on top the labels of the columns:
@@ -362,11 +362,11 @@ if __name__ == "__main__":
                     #
                     print_table = [parameter_names,fiducial,Bounds_68, Bounds_95, Bounds_99]
                     
-                    out_file.write( ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
+                    out_file.write( ''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
                     out_file.write( 'Parameter bounds for the Fisher matrix: '+fish.name+'\n' )
-                    out_file.write( ''.join([ '*' for i in xrange(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
+                    out_file.write( ''.join([ '*' for i in range(len('Parameter bounds for the Fisher matrix: '+fish.name)+1)])+'\n' )
                     out_file.write( '\n' )
-                    print_table = map(list, zip(*print_table))
+                    print_table = list(map(list, list(zip(*print_table))))
                     col_width = [max(len(str(x)) for x in col) for col in zip(*print_table)]
                     # print it to file:
                     for line in print_table:
@@ -374,7 +374,7 @@ if __name__ == "__main__":
                     out_file.write( '\n' )
                 
             if not args.quiet:
-               print ' Bounds computed for parameters '+str( fishers_temp.get_parameter_list() )
+               print(' Bounds computed for parameters '+str( fishers_temp.get_parameter_list() ))
         
         # finalize the latex part:
         if use_latex:
@@ -384,13 +384,13 @@ if __name__ == "__main__":
             out_file.close()  
         
         if not args.quiet:
-            print ' Saved results in: ', outroot+'_bounds.txt'
-            print 'bounds done!'
+            print(' Saved results in: ', outroot+'_bounds.txt')
+            print('bounds done!')
 
     # finalize:
     if not args.quiet:
-       print
-       print 'It seems everything is done...'
-       print 'It was nice working with you. See you soon!'
+       print()
+       print('It seems everything is done...')
+       print('It was nice working with you. See you soon!')
     # everything's fine, exit without error:
     exit(0)

--- a/python/apps/plot_1D.py
+++ b/python/apps/plot_1D.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
     
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot+'.'+output_format
+        print('Done. Saved results in: ', outroot+'.'+output_format)
     
     # exit without error:
     exit(0)

--- a/python/apps/plot_2D.py
+++ b/python/apps/plot_2D.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot+'.'+output_format
+        print('Done. Saved results in: ', outroot+'.'+output_format)
 
     # exit without error:
     exit(0)

--- a/python/apps/plot_cls_cov.py
+++ b/python/apps/plot_cls_cov.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     else:
         names = args.labels
     # check wether all the cls covariances have the same size:
-    for i in xrange(0, number_cls_cov):
+    for i in range(0, number_cls_cov):
         if ( data[i].shape[1] != data[0].shape[1] ):
             raise ValueError( 'The cls covariance '+names[i]+' does not have the same size as '+names[0] )
     # number of Cls:
@@ -155,15 +155,15 @@ if __name__ == "__main__":
     fig.set_size_inches( x_size, y_size )
     plot_grid = gridspec.GridSpec( num, num, wspace=x_spacing, hspace=y_spacing )
     # loop over the Cls grid:
-    for ind in xrange(1, num+1):
-        for ind2 in xrange(1, ind+1):
+    for ind in range(1, num+1):
+        for ind2 in range(1, ind+1):
     
             ax  = plt.subplot(plot_grid[ind-1,ind2-1])
             col  = ind + num*(ind2-1)
     
             plotrange_x = []
             plotrange_y = []
-            for k in xrange(0, number_cls_cov):
+            for k in range(0, number_cls_cov):
     
                 # grab the x values:
                 x_values = data[k][:,0]
@@ -217,7 +217,7 @@ if __name__ == "__main__":
             
     # create legend handlers
     leg_handlers = []
-    for k in xrange(0, len(names)):
+    for k in range(0, len(names)):
         leg_handlers.append( mlines.Line2D([], [], color=fc.nice_colors(k)) )
     # create the legend
     legend_anchor =  plot_grid[0,num-1].get_position(fig)
@@ -239,6 +239,6 @@ if __name__ == "__main__":
     plt.clf()
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot
+        print('Done. Saved results in: ', outroot)
     # exit without error:
     exit(0)

--- a/python/apps/plot_tri.py
+++ b/python/apps/plot_tri.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     
     # print some final feedback:
     if not args.quiet:
-        print 'Done. Saved results in: ', outroot+'.'+output_format
+        print('Done. Saved results in: ', outroot+'.'+output_format)
     
     # exit without error:
     exit(0)

--- a/python/cosmicfish_pylib/fisher_derived.py
+++ b/python/cosmicfish_pylib/fisher_derived.py
@@ -30,8 +30,8 @@ import os
 import math
 import copy
 import numpy as np
-import utilities as fu
-import fisher_matrix as fm
+from . import utilities as fu
+from . import fisher_matrix as fm
 
 # ***************************************************************************************
 
@@ -166,11 +166,11 @@ class fisher_derived():
             try:
                 self.load_paramnames_from_file()
             except ValueError:
-                self.param_names               = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
-                self.param_names_latex         = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
+                self.param_names               = [ 'p'+str(i+1) for i in range(self.num_params) ]
+                self.param_names_latex         = [ 'p'+str(i+1) for i in range(self.num_params) ]
                 self.param_fiducial            = np.array( [0.0 for i in self.param_names] ) 
-                self.derived_param_names       = [ 'p'+str(i+1) for i in xrange(self.num_params, self.num_derived+self.num_params) ]
-                self.derived_param_names_latex = [ 'p'+str(i+1) for i in xrange(self.num_params, self.num_derived+self.num_params) ]
+                self.derived_param_names       = [ 'p'+str(i+1) for i in range(self.num_params, self.num_derived+self.num_params) ]
+                self.derived_param_names_latex = [ 'p'+str(i+1) for i in range(self.num_params, self.num_derived+self.num_params) ]
                 self.derived_param_fiducial    = np.array( [0.0 for i in self.derived_param_names] ) 
         else:
             self.param_names                 = copy.deepcopy(param_names)
@@ -350,9 +350,9 @@ class fisher_derived():
         lower_cutoff = 10.0**(np.log10(initial_best_mode)-spectral_width)
         # check the cutoff:
         if np.amin(np.abs(w_new))<lower_cutoff or np.amax(np.abs(w_new))>upper_cutoff:
-            print 'WARNING: in add_derived name:', self.name, ' fisher:', fisher_matrix.name
-            print '** derived parameters are strongly degenerate and might alter the quality of the original Fisher matrix.'
-            print '** Try removing degenerate parameters from the Fisher matrix and the derived matrix to get rid of this warning.'
+            print('WARNING: in add_derived name:', self.name, ' fisher:', fisher_matrix.name)
+            print('** derived parameters are strongly degenerate and might alter the quality of the original Fisher matrix.')
+            print('** Try removing degenerate parameters from the Fisher matrix and the derived matrix to get rid of this warning.')
         # apply the cutoff:
         if preserve_input:
             temp = np.zeros((self.num_params + self.num_derived, self.num_params + self.num_derived), float)

--- a/python/cosmicfish_pylib/fisher_matrix.py
+++ b/python/cosmicfish_pylib/fisher_matrix.py
@@ -31,7 +31,7 @@ import os
 import math
 import copy
 import numpy as np
-import utilities as fu
+from . import utilities as fu
 
 # ***************************************************************************************
 
@@ -122,7 +122,7 @@ class fisher_matrix():
         :rtype: :class:`int` or a :class:`list` of :class:`int`
             
         """
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             return self.param_names_dict[name]-1
         elif len(name)>1:
             return [ self.param_names_dict[i]-1 for i in name ]
@@ -138,7 +138,7 @@ class fisher_matrix():
         :rtype: :class:`int` or a :class:`list` of :class:`int`
         
         """
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             return self.param_names_dict[name]
         elif len(name)>1:
             return [ self.param_names_dict[i] for i in name ]
@@ -153,7 +153,7 @@ class fisher_matrix():
         :rtype: :class:`string` or a :class:`list` of :class:`string`.
         
         """
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             return self.param_names_latex[self.get_param_index(name)]
         elif len(name)>1:
             return [ self.param_names_latex[i] for i in self.get_param_index(name) ]
@@ -168,7 +168,7 @@ class fisher_matrix():
         :rtype: :class:`float` or a :class:`list` of :class:`float`.
 
         """
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             return self.param_fiducial[self.get_param_index(name)]
         elif len(name)>1:
             return [ self.param_fiducial[i] for i in self.get_param_index(name) ]
@@ -246,8 +246,8 @@ class fisher_matrix():
             try:
                 self.load_paramnames_from_file()
             except ValueError:
-                self.param_names  = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
-                self.param_names_latex = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
+                self.param_names  = [ 'p'+str(i+1) for i in range(self.num_params) ]
+                self.param_names_latex = [ 'p'+str(i+1) for i in range(self.num_params) ]
                 self.param_fiducial    = np.array( [0.0 for i in self.param_names] ) 
         else: 
             self.param_names = copy.deepcopy(param_names)
@@ -349,7 +349,7 @@ class fisher_matrix():
         out_file.write( '# This file contains the parameter names for a Fisher matrix.\n' )
         out_file.write( '#\n' )
         # write the parameters:
-        for ind in xrange( self.num_params ):
+        for ind in range( self.num_params ):
             param_name = self.get_param_name( ind+1 )
             out_file.write( str(param_name)+'    '+ \
                             str(self.get_param_name_latex( param_name ))+'    '+ \
@@ -380,7 +380,7 @@ class fisher_matrix():
         out_file.write( '# The parameters of this Fisher matrix are:\n' )
         out_file.write( '#\n' )
         # write the param names commented:
-        for ind in xrange( self.num_params ):
+        for ind in range( self.num_params ):
             param_name = self.get_param_name( ind+1 )
             out_file.write( '#'+'    '+str(ind+1)+'    '+ \
                             str(param_name)+'    '+ \
@@ -390,8 +390,8 @@ class fisher_matrix():
         out_file.write( '#\n' )
         # write the fisher matrix:
         fisher_matrix = self.get_fisher_matrix()
-        for i in xrange( self.num_params ):
-            for j in xrange( self.num_params ):
+        for i in range( self.num_params ):
+            for j in range( self.num_params ):
                 out_file.write( str( format(fisher_matrix[i,j],'.16E') )+'     ' )
             out_file.write( '\n' )
         
@@ -416,7 +416,7 @@ class fisher_matrix():
         # check the parameters of the other Fisher matrix:
         for i in other.param_names:
             # if the parameter is in common check that they have the same fiducial value:
-            if self.param_names_dict.has_key(i):
+            if i in self.param_names_dict:
                 ind1 = self.param_names_dict[i]-1
                 ind2 = other.param_names_dict[i]-1
                 if not np.allclose( self.param_fiducial[ind1], other.param_fiducial[ind2]):
@@ -431,8 +431,8 @@ class fisher_matrix():
         num_param_new = len(param_names_new)
         new_matrix = np.zeros([num_param_new,num_param_new])
         # fill the new matrix:
-        for i in xrange(num_param_new):
-            for j in xrange(num_param_new):
+        for i in range(num_param_new):
+            for j in range(num_param_new):
                 # get the new parameters name at each entry:
                 x = param_names_new[i]
                 y = param_names_new[j]
@@ -565,7 +565,7 @@ class fisher_matrix():
         if np.abs(condition_number) > self.fisher_spectrum:
             self.fisher_cutoff = maximum_spectrum/self.fisher_spectrum
         # cycle through the eigenvalues
-        for i in xrange( len(self.fisher_eigenvalues) ):
+        for i in range( len(self.fisher_eigenvalues) ):
             # detect very small eigenvalues            
             if self.fisher_eigenvalues[i] < self.fisher_cutoff:
                 # tell the code to redo PCA:
@@ -637,8 +637,8 @@ class fisher_matrix():
         # get the number of parameters:
         self.num_params = self.fisher_matrix.shape[0]  
         # load the parameter names:
-        self.param_names       = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
-        self.param_names_latex = [ 'p'+str(i+1) for i in xrange(self.num_params) ]
+        self.param_names       = [ 'p'+str(i+1) for i in range(self.num_params) ]
+        self.param_names_latex = [ 'p'+str(i+1) for i in range(self.num_params) ]
         self.param_fiducial    = np.array( [0.0 for i in self.param_names] ) 
         # re-create a dictionary of param names:
         self.param_names_dict = {}

--- a/python/cosmicfish_pylib/fisher_operations.py
+++ b/python/cosmicfish_pylib/fisher_operations.py
@@ -26,7 +26,7 @@
 # ***************************************************************************************
 
 import numpy as np
-import fisher_matrix as fm
+from . import fisher_matrix as fm
 import math
 
 # ***************************************************************************************
@@ -53,7 +53,7 @@ def eliminate_columns_rows( fisher_matrix, indexes ):
     new_param_names       = []
     new_param_names_latex = []
     new_param_fiducial    = []
-    for i in xrange( fisher_matrix.num_params ):
+    for i in range( fisher_matrix.num_params ):
         if i not in indexes:
             new_param_names.append( fisher_matrix.param_names[i] )
             new_param_names_latex.append( fisher_matrix.param_names_latex[i] )
@@ -90,7 +90,7 @@ def eliminate_parameters( fisher_matrix, names ):
     # get the indexes of the parameters:
     index_list = []
     for i in names:
-        if not fisher_matrix.param_names_dict.has_key(i):
+        if i not in fisher_matrix.param_names_dict:
             raise ValueError('Error, parameter '+str(i)+' is not in a parameter of fisher_matrix')
         index_list.append(fisher_matrix.param_names_dict[i]-1)
     # elminate them from the list and return:
@@ -119,7 +119,7 @@ def reshuffle( fisher_matrix, names ):
             raise ValueError('Error, input fisher_matrix is not a fisher_matrix')
     # check wether the names required are inside the Fisher matrix:
     for i in names:
-        if not fisher_matrix.param_names_dict.has_key(i):
+        if i not in fisher_matrix.param_names_dict:
             raise ValueError('Error, parameter '+str(i)+' is not in a parameter of fisher_matrix')
     # get the new latex names and fiducial:
     new_param_names_latex = []
@@ -132,8 +132,8 @@ def reshuffle( fisher_matrix, names ):
     num_param_new = len(names)
     new_matrix = np.zeros([num_param_new,num_param_new])    
     # fill the new matrix:
-    for i in xrange(num_param_new):
-        for j in xrange(num_param_new):
+    for i in range(num_param_new):
+        for j in range(num_param_new):
             # get the name:
             x = names[i]
             y = names[j]
@@ -173,7 +173,7 @@ def marginalise( fisher_matrix, names ):
             raise ValueError('Error, input fisher_matrix is not a fisher_matrix')
     # check wether the names required are inside the Fisher matrix:
     for i in names:
-        if not fisher_matrix.param_names_dict.has_key(i):
+        if i not in fisher_matrix.param_names_dict:
             raise ValueError('Error, parameter '+str(i)+' is not in a parameter of fisher_matrix')
     # get the new latex names and fiducial:
     new_param_names_latex = []
@@ -186,8 +186,8 @@ def marginalise( fisher_matrix, names ):
     num_param_new = len(names)
     new_matrix = np.zeros([num_param_new,num_param_new])    
     # fill the new inverse matrix:
-    for i in xrange(num_param_new):
-        for j in xrange(num_param_new):
+    for i in range(num_param_new):
+        for j in range(num_param_new):
             # get the name:
             x = names[i]
             y = names[j]
@@ -227,7 +227,7 @@ def marginalise_over( fisher_matrix, names ):
             raise ValueError('Error, input fisher_matrix is not a fisher_matrix')
     # check wether the names required are inside the Fisher matrix:
     for i in names:
-        if not fisher_matrix.param_names_dict.has_key(i):
+        if i not in fisher_matrix.param_names_dict:
             raise ValueError('Error, parameter '+str(i)+' is not in a parameter of fisher_matrix')
     # get the indexes:
     new_names = [ i for i in fisher_matrix.param_names if i not in names ]

--- a/python/cosmicfish_pylib/fisher_plot.py
+++ b/python/cosmicfish_pylib/fisher_plot.py
@@ -38,11 +38,11 @@ import matplotlib.gridspec as gridspec
 import matplotlib.patches  as mpatches
 import matplotlib.lines    as mlines
 
-import utilities     as fu
-import fisher_matrix as fm
-import fisher_plot_analysis as fpa
+from . import utilities     as fu
+from . import fisher_matrix as fm
+from . import fisher_plot_analysis as fpa
 
-from fisher_plot_settings import *
+from .fisher_plot_settings import *
 
 # ***************************************************************************************
 
@@ -529,7 +529,7 @@ class CosmicFishPlotter():
             subplot.set_xticklabels( [] )
         else:
             xticks = np.linspace(x_limits[0], x_limits[1], number_x_ticks)
-            xticks = [ u'$'+str('{}'.format(i))+'$' for i in xticks ]
+            xticks = [ '$'+str('{}'.format(i))+'$' for i in xticks ]
             subplot.set_xticklabels( xticks, fontsize=secondary_fontsize )
             if xlabel_up: subplot.xaxis.tick_top()
         # yticks:
@@ -537,7 +537,7 @@ class CosmicFishPlotter():
             subplot.set_yticklabels( [] )
         else:
             yticks = np.linspace(0,1, number_y_ticks) 
-            yticks = [ u'$'+str('{}'.format(i))+'$' for i in yticks ]
+            yticks = [ '$'+str('{}'.format(i))+'$' for i in yticks ]
             subplot.set_yticklabels( yticks, fontsize=secondary_fontsize )
             if ylabel_right: subplot.yaxis.tick_right()
         # align the left and right tick labels:
@@ -550,7 +550,7 @@ class CosmicFishPlotter():
             pass
         # set axis labels:
         if show_xaxis_label:
-            subplot.set_xlabel( u'$'+self.plot_fishers.get_parameter_latex_names()[param]+'$', fontsize=main_fontsize, rotation=x_label_rotation )
+            subplot.set_xlabel( '$'+self.plot_fishers.get_parameter_latex_names()[param]+'$', fontsize=main_fontsize, rotation=x_label_rotation )
             if xlabel_up: subplot.xaxis.set_label_position("top")
         if show_yaxis_label:
             if normalized:
@@ -649,7 +649,7 @@ class CosmicFishPlotter():
             subplot.set_xticklabels( [] )
         else:
             xticks = np.linspace(ranges[param1][0], ranges[param1][1], number_x_ticks)
-            xticks = [ u'$'+str('{}'.format(i))+'$' for i in xticks ]
+            xticks = [ '$'+str('{}'.format(i))+'$' for i in xticks ]
             subplot.set_xticklabels( xticks, fontsize=secondary_fontsize )
             if xlabel_up: subplot.xaxis.tick_top()
         # yticks:
@@ -657,7 +657,7 @@ class CosmicFishPlotter():
             subplot.set_yticklabels( [] )
         else:
             yticks = np.linspace( ranges[param2][0], ranges[param2][1], number_y_ticks)
-            yticks = [ u'$'+str('{}'.format(i))+'$' for i in yticks ]
+            yticks = [ '$'+str('{}'.format(i))+'$' for i in yticks ]
             subplot.set_yticklabels( yticks, fontsize=secondary_fontsize )
             if ylabel_right: subplot.yaxis.tick_right()
         # align the left and right tick labels:
@@ -670,10 +670,10 @@ class CosmicFishPlotter():
             pass
         # set axis labels:
         if show_xaxis_label:
-            subplot.set_xlabel( u'$'+self.plot_fishers.get_parameter_latex_names()[param1]+'$', fontsize=main_fontsize, rotation=x_label_rotation )
+            subplot.set_xlabel( '$'+self.plot_fishers.get_parameter_latex_names()[param1]+'$', fontsize=main_fontsize, rotation=x_label_rotation )
             if xlabel_up: subplot.xaxis.set_label_position("top")
         if show_yaxis_label:
-            subplot.set_ylabel( u'$'+self.plot_fishers.get_parameter_latex_names()[param2]+'$', fontsize=main_fontsize, rotation=y_label_rotation )
+            subplot.set_ylabel( '$'+self.plot_fishers.get_parameter_latex_names()[param2]+'$', fontsize=main_fontsize, rotation=y_label_rotation )
             if ylabel_right: subplot.yaxis.set_label_position("right")    
                 
     # -----------------------------------------------------------------------------------
@@ -690,7 +690,7 @@ class CosmicFishPlotter():
             otherwise the value in :class:`cosmicfish_pylib.fisher_plot.CosmicFishPlotter.plot_settings`
         
         """
-        if kwargs.has_key(key): 
+        if key in kwargs: 
             return kwargs[key]
         else:
             try:
@@ -719,7 +719,7 @@ class CosmicFishPlotter():
         # let's start with colors. We want them binded to names so there is consistency of colors through plots.
         # line colors
         self.bind_line_colors = {}
-        if kwargs.has_key('line_colors'): 
+        if 'line_colors' in kwargs: 
             for i, name in enumerate(names_temp):
                 self.bind_line_colors[name] = kwargs['line_colors'][i]
         else:
@@ -727,7 +727,7 @@ class CosmicFishPlotter():
                 self.bind_line_colors[name] = self.plot_settings.line_colors[i]
         # solid colors
         self.bind_solid_colors = {}
-        if kwargs.has_key('solid_colors'): 
+        if 'solid_colors' in kwargs: 
             for i, name in enumerate(names_temp):
                 self.bind_solid_colors[name] = kwargs['solid_colors'][i]
         else:
@@ -735,7 +735,7 @@ class CosmicFishPlotter():
                 self.bind_solid_colors[name] = self.plot_settings.solid_colors[i]
         # labels:
         self.bind_labels = {}
-        if kwargs.has_key('labels'): 
+        if 'labels' in kwargs: 
             for i, name in enumerate(names_temp):
                 self.bind_labels[name] = kwargs['labels'][i]
         else:
@@ -743,7 +743,7 @@ class CosmicFishPlotter():
                 self.bind_labels[name] = name
         # linestyle:
         self.bind_linestyle = {}
-        if kwargs.has_key('linestyle'): 
+        if 'linestyle' in kwargs: 
             for i, name in enumerate(names_temp):
                 self.bind_linestyle[name] = kwargs['linestyle'][i]
         else:
@@ -776,7 +776,7 @@ class CosmicFishPlotter():
         sizes_dictionary['figure'] = self.figure.get_size_inches() #: in inches
         # get max (x,y) size of the y ticks:
         max_y_tick_label = [0.0,0.0]
-        for plot in self.plot_dict.values():
+        for plot in list(self.plot_dict.values()):
             for ylabel in plot.get_yticklabels():
                 x_dimension = ylabel.get_window_extent(renderer).width/default_dpi  #: in inches
                 y_dimension = ylabel.get_window_extent(renderer).height/default_dpi  #: in inches
@@ -785,7 +785,7 @@ class CosmicFishPlotter():
         sizes_dictionary['y_tick_labels'] = max_y_tick_label #: in inches
         # get max (x,y) size of the x ticks:
         max_x_tick_label = [0.0,0.0]
-        for plot in self.plot_dict.values():
+        for plot in list(self.plot_dict.values()):
             for xlabel in plot.get_xticklabels():
                 x_dimension = xlabel.get_window_extent(renderer).width/default_dpi  #: in inches
                 y_dimension = xlabel.get_window_extent(renderer).height/default_dpi  #: in inches
@@ -794,7 +794,7 @@ class CosmicFishPlotter():
         sizes_dictionary['x_tick_labels'] = max_x_tick_label #: in inches
         # get max (x,y) size of the y label:
         max_y_label = [0.0,0.0]
-        for plot in self.plot_dict.values():    
+        for plot in list(self.plot_dict.values()):    
             x_dimension = plot.yaxis.get_label().get_window_extent(renderer).width/default_dpi  #: in inches
             y_dimension = plot.yaxis.get_label().get_window_extent(renderer).height/default_dpi  #: in inches
             if x_dimension>max_y_label[0]: max_y_label[0]=x_dimension
@@ -802,7 +802,7 @@ class CosmicFishPlotter():
         sizes_dictionary['y_labels'] = max_y_label #: in inches 
         # get max (x,y) size of the x label:
         max_x_label = [0.0,0.0]
-        for plot in self.plot_dict.values():     
+        for plot in list(self.plot_dict.values()):     
             x_dimension = plot.xaxis.get_label().get_window_extent(renderer).width/default_dpi  #: in inches
             y_dimension = plot.xaxis.get_label().get_window_extent(renderer).height/default_dpi  #: in inches
             if x_dimension>max_x_label[0]: max_x_label[0]=x_dimension
@@ -892,19 +892,19 @@ class CosmicFishPlotter():
         # compute the global paddings, and the space between sub plots
         wspace = ( +dimensions['ytick_pad'] +2.0*dimensions['label_pad'] +dimensions['y_tick_labels'][0] +dimensions['y_labels'][0] )/2.0
         hspace = ( +dimensions['xtick_pad'] +2.0*dimensions['label_pad'] +dimensions['x_tick_labels'][1] +dimensions['x_labels'][1] )/2.0
-        if 'left' in [ subplot.yaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'left' in [ subplot.yaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             left   = 2.0*wspace
         else:
             left   = small_space
-        if 'right' in [ subplot.yaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'right' in [ subplot.yaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             right  = x_size - 2.0*wspace
         else:
             right  = x_size - small_space
-        if 'bottom' in [ subplot.xaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'bottom' in [ subplot.xaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             bottom  = 2.0*hspace
         else:
             bottom  = small_space
-        if 'top' in [ subplot.xaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'top' in [ subplot.xaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             top  = y_size - 2.0*hspace
         else:
             top  = y_size - small_space
@@ -1014,19 +1014,19 @@ class CosmicFishPlotter():
         # compute the global paddings, and the space between sub plots
         wspace = ( +dimensions['ytick_pad'] +2.0*dimensions['label_pad'] +dimensions['y_tick_labels'][0] +dimensions['y_labels'][0] )/2.0
         hspace = ( +dimensions['xtick_pad'] +2.0*dimensions['label_pad'] +dimensions['x_tick_labels'][1] +dimensions['x_labels'][1] )/2.0
-        if 'left' in [ subplot.yaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'left' in [ subplot.yaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             left   = 2.0*wspace
         else:
             left   = small_space
-        if 'right' in [ subplot.yaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'right' in [ subplot.yaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             right  = x_size - 2.0*wspace
         else:
             right  = x_size - small_space
-        if 'bottom' in [ subplot.xaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'bottom' in [ subplot.xaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             bottom  = 2.0*hspace
         else:
             bottom  = small_space
-        if 'top' in [ subplot.xaxis.get_label_position() for subplot in self.plot_dict.values() ]:
+        if 'top' in [ subplot.xaxis.get_label_position() for subplot in list(self.plot_dict.values()) ]:
             top  = y_size - 2.0*hspace
         else:
             top  = y_size - small_space
@@ -1110,7 +1110,7 @@ class CosmicFishPlotter():
                 leg_handlers.append( mlines.Line2D([], [], color = self.bind_line_colors[name],
                                                    linestyle = self.bind_linestyle[name], ) )
         # process names:
-        names_legend = [ u'$\\mathrm{'+str(i).replace(" ", "\ ").replace('_', '\ ')+'}$' for i in names_temp]
+        names_legend = [ '$\\mathrm{'+str(i).replace(" ", "\ ").replace('_', '\ ')+'}$' for i in names_temp]
         self.legend = self.figure.legend( handles  = leg_handlers, 
                                           labels   = names_legend, 
                                           fontsize = main_fontsize,
@@ -1139,7 +1139,7 @@ class CosmicFishPlotter():
         # override settings:
         fontsize = self.setting_setter('title_fontsize', **kwargs)
         # create the title:
-        self.title = self.figure.suptitle( u'$\\mathrm{'+str(title).replace(" ", "\ ")+'}$', fontsize=fontsize )
+        self.title = self.figure.suptitle( '$\\mathrm{'+str(title).replace(" ", "\ ")+'}$', fontsize=fontsize )
         
     # -----------------------------------------------------------------------------------
     

--- a/python/cosmicfish_pylib/fisher_plot.py
+++ b/python/cosmicfish_pylib/fisher_plot.py
@@ -282,9 +282,9 @@ class CosmicFishPlotter():
         if legend_takes_place_plot: num_plots = num_plots +1
         # get the number of rows:
         if num_plots%plot_per_line == 0: 
-            num_row = max(1,num_plots/plot_per_line)
+            num_row = max(1,num_plots//plot_per_line)
         else: 
-            num_row = max(1,num_plots/plot_per_line+1)
+            num_row = max(1,num_plots//plot_per_line+1)
         # get the number of columns:
         num_col = min( num_plots, plot_per_line )
         # create the layout of the figure:
@@ -294,8 +294,8 @@ class CosmicFishPlotter():
         self.plot_dict = {}
         for i,j in enumerate(params_temp):
             # generate the dictionary: we want symmetric keys just to be sure.
-            self.plot_dict['['+str(j[0])+','+str(j[1])+']'] = plt.subplot(self.plot_grid[i/plot_per_line,i%plot_per_line])
-            self.plot_dict['['+str(j[1])+','+str(j[0])+']'] = plt.subplot(self.plot_grid[i/plot_per_line,i%plot_per_line])
+            self.plot_dict['['+str(j[0])+','+str(j[1])+']'] = plt.subplot(self.plot_grid[i//plot_per_line,i%plot_per_line])
+            self.plot_dict['['+str(j[1])+','+str(j[0])+']'] = plt.subplot(self.plot_grid[i//plot_per_line,i%plot_per_line])
             # create the figures:
             self.figure_2D( subplot=self.plot_dict['['+str(j[0])+','+str(j[1])+']'], param1=j[0], param2=j[1], names=names_temp, **kwargs )
         # do the legend:
@@ -937,7 +937,7 @@ class CosmicFishPlotter():
             if legend_takes_place_plot:
                 num_plots = self.plot_number
                 plot_per_line = self.plot_grid.get_geometry()[1]
-                bbox     = self.plot_grid[(num_plots-1)/plot_per_line,(num_plots-1)%plot_per_line].get_position(self.figure)
+                bbox     = self.plot_grid[(num_plots-1)//plot_per_line,(num_plots-1)%plot_per_line].get_position(self.figure)
                 self.legend.set_bbox_to_anchor( bbox=bbox )
             
         # position the title:

--- a/python/cosmicfish_pylib/fisher_plot.py
+++ b/python/cosmicfish_pylib/fisher_plot.py
@@ -211,9 +211,9 @@ class CosmicFishPlotter():
         if legend_takes_place_plot: num_plots = num_plots +1
         # get the number of rows:
         if num_plots%plot_per_line == 0: 
-            num_row = max(1,num_plots/plot_per_line)
+            num_row = max(1,num_plots//plot_per_line)
         else: 
-            num_row = max(1,num_plots/plot_per_line+1)
+            num_row = max(1,num_plots//plot_per_line+1)
         # get the number of columns:
         num_col = min( num_plots, plot_per_line )
         # create the layout of the figure:
@@ -222,7 +222,7 @@ class CosmicFishPlotter():
         # fill the single plotters:
         self.plot_dict = {}
         for i,j in enumerate(params_temp):
-            self.plot_dict[j] = plt.subplot( self.plot_grid[i/plot_per_line,i%plot_per_line] )
+            self.plot_dict[j] = plt.subplot( self.plot_grid[i//plot_per_line,i%plot_per_line] )
             self.figure_1D( subplot=self.plot_dict[j], param=j, names=names_temp, **kwargs)
         # do the legend:
         self.set_legend( names=names_temp, **kwargs )

--- a/python/cosmicfish_pylib/fisher_plot_analysis.py
+++ b/python/cosmicfish_pylib/fisher_plot_analysis.py
@@ -426,7 +426,7 @@ class CosmicFish_FisherAnalysis():
         # compute the confidence coefficient:
         confidence_coefficient = fu.confidence_coefficient( confidence_level )
         # get the ranges:
-        range = []
+        range_temp = []
         for i in params_temp:
             lower_bound = []
             upper_bound  = []
@@ -453,13 +453,13 @@ class CosmicFish_FisherAnalysis():
             # decide what to use:
             upper_bound = np.array(upper_bound)
             lower_bound = np.array(lower_bound)
-            range.append([ float(str(np.amin(lower_bound))), float(str(np.amax(upper_bound))) ])
+            range_temp.append([ float(str(np.amin(lower_bound))), float(str(np.amax(upper_bound))) ])
         
-        dict = {}
+        result = {}
         for i,j in zip(params_temp,range(len(params_temp))):
-            dict[i] = range[j]
+            result[i] = range_temp[j]
             
-        return dict
+        return result
             
     # -----------------------------------------------------------------------------------
     

--- a/python/cosmicfish_pylib/fisher_plot_analysis.py
+++ b/python/cosmicfish_pylib/fisher_plot_analysis.py
@@ -28,13 +28,13 @@ import os
 import math
 import copy
 import numpy as np
-import utilities         as fu
-import fisher_matrix     as fm
-import fisher_derived    as fd
-import fisher_operations as fo
-from __builtin__ import dict
+from . import utilities         as fu
+from . import fisher_matrix     as fm
+from . import fisher_derived    as fd
+from . import fisher_operations as fo
+from builtins import dict
 
-import __init__ as CosmicFishPyLib
+from . import __init__ as CosmicFishPyLib
 
 # ***************************************************************************************
 
@@ -160,38 +160,38 @@ class CosmicFish_FisherAnalysis():
                     
         # import fisher matrices:
         for file in fisher_files:
-            if CosmicFishPyLib.__feedback__ > 1: print 'Trying to import: '+file+' as a Fisher matrix: ',
+            if CosmicFishPyLib.__feedback__ > 1: print('Trying to import: '+file+' as a Fisher matrix: ', end=' ')
             try:    
                 self.fisher_list.append( fm.fisher_matrix( file_name = file ))
                 self.fisher_name_list.append( self.fisher_list[-1].name )
-                if CosmicFishPyLib.__feedback__ > 1: print 'SUCCESS'
-                if CosmicFishPyLib.__feedback__ == 1: print 'Imported as a Fisher matrix: '+file
+                if CosmicFishPyLib.__feedback__ > 1: print('SUCCESS')
+                if CosmicFishPyLib.__feedback__ == 1: print('Imported as a Fisher matrix: '+file)
                 # remove from the derived fishers if necessary:
                 derived_fisher_files.remove(file)
             except:
-                if CosmicFishPyLib.__feedback__ > 1: print 'FAIL'
+                if CosmicFishPyLib.__feedback__ > 1: print('FAIL')
         # import derived fisher matrices:
         if with_derived:
             for file in derived_fisher_files:
                 # get the derived matrix:
-                if CosmicFishPyLib.__feedback__ > 1: print 'Trying to import: '+file+' as a derived Fisher matrix: ',
+                if CosmicFishPyLib.__feedback__ > 1: print('Trying to import: '+file+' as a derived Fisher matrix: ', end=' ')
                 try:    
                     fisher_derived = fd.fisher_derived( file_name = file )
-                    if CosmicFishPyLib.__feedback__ > 1: print 'SUCCESS'
+                    if CosmicFishPyLib.__feedback__ > 1: print('SUCCESS')
                 except: 
                     fisher_derived = None
-                    if CosmicFishPyLib.__feedback__ > 1: print 'FAIL'
+                    if CosmicFishPyLib.__feedback__ > 1: print('FAIL')
                 # add derived to the fisher matrix when possible:
                 if fisher_derived is not None:
-                    for i in xrange( len( self.fisher_name_list) ):
-                        if CosmicFishPyLib.__feedback__ > 1: print 'Trying to add derived from: '+fisher_derived.name+' to the Fisher matrix: '+self.fisher_list[i].name,
+                    for i in range( len( self.fisher_name_list) ):
+                        if CosmicFishPyLib.__feedback__ > 1: print('Trying to add derived from: '+fisher_derived.name+' to the Fisher matrix: '+self.fisher_list[i].name, end=' ')
                         try: 
                             self.fisher_list[i] = fisher_derived.add_derived( fisher_matrix=self.fisher_list[i], preserve_input=True )
                             self.fisher_name_list[i] = self.fisher_list[i].name 
-                            if CosmicFishPyLib.__feedback__ > 1: print 'SUCCESS'
-                            if CosmicFishPyLib.__feedback__ == 1: print 'Added derived parameters from: '+fisher_derived.name+' to Fisher matrix: '+self.fisher_list[i].name
+                            if CosmicFishPyLib.__feedback__ > 1: print('SUCCESS')
+                            if CosmicFishPyLib.__feedback__ == 1: print('Added derived parameters from: '+fisher_derived.name+' to Fisher matrix: '+self.fisher_list[i].name)
                         except:
-                            if CosmicFishPyLib.__feedback__ > 1: print 'FAIL'
+                            if CosmicFishPyLib.__feedback__ > 1: print('FAIL')
                 
     # -----------------------------------------------------------------------------------
     
@@ -270,7 +270,7 @@ class CosmicFish_FisherAnalysis():
         # get indeces to delete:
         indexes_to_delete = [ i for i, s in enumerate(self.fisher_name_list) if s in names_to_delete ]
         # delete them. We have to use this way because fisher_matrix might not have a delete method and we do not want to move in memory the arrays.
-        for i in xrange(len(indexes_to_delete)):
+        for i in range(len(indexes_to_delete)):
             self.fisher_name_list.pop(indexes_to_delete[i]-i)
             self.fisher_list.pop(indexes_to_delete[i]-i)
         
@@ -387,7 +387,7 @@ class CosmicFish_FisherAnalysis():
                     latex_names[name] = fish.get_param_name_latex(name)
                 except:
                     continue
-                if latex_names.has_key(name): continue
+                if name in latex_names: continue
         
         return latex_names
     
@@ -456,7 +456,7 @@ class CosmicFish_FisherAnalysis():
             range.append([ float(str(np.amin(lower_bound))), float(str(np.amax(upper_bound))) ])
         
         dict = {}
-        for i,j in zip(params_temp,xrange(len(params_temp))):
+        for i,j in zip(params_temp,range(len(params_temp))):
             dict[i] = range[j]
             
         return dict

--- a/python/cosmicfish_pylib/fisher_plot_settings.py
+++ b/python/cosmicfish_pylib/fisher_plot_settings.py
@@ -181,8 +181,8 @@ class CosmicFish_PlotSettings():
         self.D1_show_yaxis_label     = True                
         self.D1_x_label_rotation     = 0                   
         self.D1_y_label_rotation     = 90                  
-        self.D1_prob_label           = u'$P/P_{\\rm max}$' 
-        self.D1_norm_prob_label      = u'$P$'              
+        self.D1_prob_label           = '$P/P_{\\rm max}$' 
+        self.D1_norm_prob_label      = '$P$'              
         self.D1_main_fontsize        = 10.0                
         self.D1_secondary_fontsize   = 9.0                 
         self.D1_show_best_fit        = False               
@@ -255,12 +255,12 @@ class CosmicFish_PlotSettings():
             if not isinstance(dictionary, dict):
                 raise ValueError('Invalid input. Dictionary shall be a dictionary of settings.')
             else:
-                temp = [ key for key in dictionary.keys() if key in __accepted_settings__ ]
+                temp = [ key for key in list(dictionary.keys()) if key in __accepted_settings__ ]
                 for key in temp:
                     setattr(self, key, dictionary[key])
         # now parse kwargs. Esplicit kwarg takes precedence wrt dictionary:
         if kwargs is not None:
-            temp = [ key for key in kwargs.keys() if key in __accepted_settings__ ]
+            temp = [ key for key in list(kwargs.keys()) if key in __accepted_settings__ ]
             for key in temp:
                 setattr(self, key, kwargs[key])
             
@@ -286,12 +286,12 @@ class CosmicFish_PlotSettings():
             if not isinstance(dictionary, dict):
                 raise ValueError('Invalid input. Dictionary shall be a dictionary of settings.')
             else:
-                temp = [ key for key in dictionary.keys() if key in __accepted_settings__ ]
+                temp = [ key for key in list(dictionary.keys()) if key in __accepted_settings__ ]
                 for key in temp:
                     setattr(self, key, dictionary[key])
         # now parse kwargs. Esplicit kwarg takes precedence wrt dictionary:
         if kwargs is not None:
-            temp = [ key for key in kwargs.keys() if key in __accepted_settings__ ]
+            temp = [ key for key in list(kwargs.keys()) if key in __accepted_settings__ ]
             for key in temp:
                 setattr(self, key, kwargs[key])
         

--- a/python/cosmicfish_pylib/utilities.py
+++ b/python/cosmicfish_pylib/utilities.py
@@ -159,14 +159,14 @@ def print_table(table):
 
     """
     # transpose the table:
-    table = map(list, zip(*table))
+    table = list(map(list, list(zip(*table))))
     # get the column width:
     col_width = [max(len(str(x)) for x in col) for col in zip(*table)]
     # print it to screen:
-    print
+    print()
     for line in table:
-        print "| " + " | ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " |"
-    print
+        print("| " + " | ".join("{:{}}".format(x, col_width[i]) for i, x in enumerate(line)) + " |")
+    print()
 
 # ***************************************************************************************
 
@@ -214,17 +214,17 @@ def CosmicFish_write_header(name):
     
     """
 
-    print
-    print "**************************************************************"
-    print "   _____               _     _____     __  "
-    print "  / ___/__  ___ __ _  (_)___/ __(_)__ / /  "
-    print " / /__/ _ \(_-</  ' \/ / __/ _// (_-</ _ \ "
-    print " \___/\___/___/_/_/_/_/\__/_/ /_/___/_//_/ Py Lib"
-    print " "
-    print "**************************************************************"
-    print name
-    print " This application was developed using the CosmicFish code."
-    print "**************************************************************"
-    print
+    print()
+    print("**************************************************************")
+    print("   _____               _     _____     __  ")
+    print("  / ___/__  ___ __ _  (_)___/ __(_)__ / /  ")
+    print(" / /__/ _ \(_-</  ' \/ / __/ _// (_-</ _ \ ")
+    print(" \___/\___/___/_/_/_/_/\__/_/ /_/___/_//_/ Py Lib")
+    print(" ")
+    print("**************************************************************")
+    print(name)
+    print(" This application was developed using the CosmicFish code.")
+    print("**************************************************************")
+    print()
     
 # ***************************************************************************************

--- a/python/cosmicfish_pylib/utilities.py
+++ b/python/cosmicfish_pylib/utilities.py
@@ -200,7 +200,7 @@ def grouper( n, iterable, fillvalue=None ):
 
     """
     args = [iter(iterable)]*n
-    return list( it.izip_longest(fillvalue=fillvalue, *args) )
+    return list( it.zip_longest(fillvalue=fillvalue, *args) )
 
 # ***************************************************************************************
 

--- a/python/cosmicfish_pylib_test/test_colors.py
+++ b/python/cosmicfish_pylib_test/test_colors.py
@@ -28,7 +28,7 @@ import cosmicfish_pylib.colors as col
 # ***************************************************************************************
 
 def test_nice_colors():
-    for i in xrange(10):
+    for i in range(10):
         # check that the entrances are 3:
         assert len(col.nice_colors(i))==3
         # check that they are positive and smaller than 1, i.e. it is legal RGB:
@@ -40,13 +40,13 @@ def test_nice_colors():
 
 def test_bash_colors():
     color_print = col.bash_colors()
-    print 
-    print color_print.header(__name__+'.test_bash_colors: Header color')
-    print color_print.blue(__name__+'.test_bash_colors: Blue color')
-    print color_print.green(__name__+'.test_bash_colors: Green color')
-    print color_print.warning(__name__+'.test_bash_colors: Warning color')
-    print color_print.fail(__name__+'.test_bash_colors: Fail color')
-    print color_print.bold(__name__+'.test_bash_colors: Bold color')
-    print color_print.underline(__name__+'.test_bash_colors: Underline color')
+    print() 
+    print(color_print.header(__name__+'.test_bash_colors: Header color'))
+    print(color_print.blue(__name__+'.test_bash_colors: Blue color'))
+    print(color_print.green(__name__+'.test_bash_colors: Green color'))
+    print(color_print.warning(__name__+'.test_bash_colors: Warning color'))
+    print(color_print.fail(__name__+'.test_bash_colors: Fail color'))
+    print(color_print.bold(__name__+'.test_bash_colors: Bold color'))
+    print(color_print.underline(__name__+'.test_bash_colors: Underline color'))
     
 # ***************************************************************************************

--- a/python/cosmicfish_pylib_test/test_fisher_derived.py
+++ b/python/cosmicfish_pylib_test/test_fisher_derived.py
@@ -37,16 +37,16 @@ class test_getters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_getters.setup_class() ----------')
+        print(color_print.header( __name__+': test_getters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_getters.teardown_class() -------')
+        print(color_print.bold( __name__+': test_getters.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
         # Jacobian matrix:
         matrix_derived = np.zeros( (3, 2) )
@@ -54,11 +54,11 @@ class test_getters():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         # initialize the derived matrix:
@@ -96,11 +96,11 @@ class test_fisher_derived_init():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_derived_init.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_derived_init.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_derived_init.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_derived_init.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -159,11 +159,11 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         # after calling init all the objects of the class have to be initialized properly:
@@ -186,13 +186,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(4) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(4) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -208,13 +208,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(4) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(4) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -230,13 +230,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(3) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(3) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -252,13 +252,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(3) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(3) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -274,13 +274,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(4) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(4) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -296,13 +296,13 @@ class test_fisher_derived_init():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(3) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(3) ]
         # initialize the derived matrix:
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError,  fd.fisher_derived, derived_matrix=matrix_derived,
@@ -318,11 +318,11 @@ class test_fisher_derived_load_paramnames_from_file():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_derived_load_paramnames_from_file.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_derived_load_paramnames_from_file.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_derived_load_paramnames_from_file.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_derived_load_paramnames_from_file.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -333,12 +333,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_1_derived.paramnames')
         # test if everything is properly initialized:
@@ -355,12 +355,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_2_derived.paramnames')
         # test if everything is properly initialized:
@@ -377,12 +377,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_3_derived.paramnames')
         # test if everything is properly initialized:
@@ -399,12 +399,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(2) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(2) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_4_derived.paramnames')
         # test if everything is properly initialized:
@@ -421,12 +421,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(4) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(4) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(4) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(4) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(4) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(4) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_5_derived.paramnames')
         # test if everything is properly initialized:
@@ -443,12 +443,12 @@ class test_fisher_derived_load_paramnames_from_file():
         matrix_derived[0,0] = 1.0
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
-        param_names = [ 'q'+str(i) for i in xrange(3) ]   
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names = [ 'qd'+str(i) for i in xrange(4) ]   
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(4) ]
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(4) ]
+        param_names = [ 'q'+str(i) for i in range(3) ]   
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names = [ 'qd'+str(i) for i in range(4) ]   
+        derived_param_names_latex = [ 'md'+str(i) for i in range(4) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(4) ]
         fisher_1 = fd.fisher_derived( derived_matrix=matrix_derived )
         assert_raises( ValueError, fisher_1.load_paramnames_from_file, file_name=test_input+'/dummy_paramnames_5_derived.paramnames' )
 
@@ -458,16 +458,16 @@ class test_add_derived():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_add_derived.setup_class() ----------')
+        print(color_print.header( __name__+': test_add_derived.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_add_derived.teardown_class() -------')
+        print(color_print.bold( __name__+': test_add_derived.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
         # Jacobian matrix:
         matrix_derived = np.zeros( (3, 2) )
@@ -475,11 +475,11 @@ class test_add_derived():
         matrix_derived[1,1] = 1.0
         matrix_derived[2,0] = 1.0
         # parameter names:
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         # initialize the derived matrix:
@@ -492,12 +492,12 @@ class test_add_derived():
         assert_raises( ValueError, self.fisher_der.add_derived, fisher_matrix=[0.0] )
     
     def test_invalid_names(self):
-        fake_names = [ 'm'+str(i) for i in xrange(3) ]
+        fake_names = [ 'm'+str(i) for i in range(3) ]
         self.fisher_1.set_param_names( fake_names )
         assert_raises( ValueError, self.fisher_der.add_derived, fisher_matrix=self.fisher_1 )
         
     def test_invalid_fiducial(self):
-        fake_fiducial = [ float(i+1) for i in xrange(3) ]
+        fake_fiducial = [ float(i+1) for i in range(3) ]
         self.fisher_1.set_fiducial( fake_fiducial )
         assert_raises( ValueError, self.fisher_der.add_derived, fisher_matrix=self.fisher_1 )
         
@@ -529,11 +529,11 @@ class test_add_derived():
         matrix_derived[0,0] = 1.e10
         matrix_derived[2,0] = 1.e-10
         # parameter names:
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ]
-        derived_param_names_latex = [ 'md'+str(i) for i in xrange(2) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ]
+        derived_param_names_latex = [ 'md'+str(i) for i in range(2) ]
         # fiducial:
-        fiducial = [ float(i) for i in xrange(3) ]
-        fiducial_derived = [ float(i) for i in xrange(2) ]
+        fiducial = [ float(i) for i in range(3) ]
+        fiducial_derived = [ float(i) for i in range(2) ]
         # initialize the derived matrix:
         fisher_der = fd.fisher_derived( derived_matrix=matrix_derived, 
                                              param_names_latex=param_names_latex, 

--- a/python/cosmicfish_pylib_test/test_fisher_matrix.py
+++ b/python/cosmicfish_pylib_test/test_fisher_matrix.py
@@ -15,7 +15,6 @@
 
 # import first packages
 import os, sys
-from dircache import cache
 # define path to the executable and add all the relevant folders to the path where python looks for files.
 here = os.path.dirname(os.path.abspath(__file__))
 cosmicfish_pylib_path = here+'/..'

--- a/python/cosmicfish_pylib_test/test_fisher_matrix.py
+++ b/python/cosmicfish_pylib_test/test_fisher_matrix.py
@@ -38,19 +38,19 @@ class test_getters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_getters.setup_class() ----------')
+        print(color_print.header( __name__+': test_getters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_getters.teardown_class() -------')
+        print(color_print.bold( __name__+': test_getters.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
 
@@ -106,19 +106,19 @@ class test_advanced_getters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_advanced_getters.setup_class() ----------')
+        print(color_print.header(__name__+': test_advanced_getters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_advanced_getters.teardown_class() -------')
+        print(color_print.bold(__name__+': test_advanced_getters.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
 
@@ -159,11 +159,11 @@ class test_fisher_init():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_init.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_init.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_init.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_init.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -174,9 +174,9 @@ class test_fisher_init():
     
     def test_init_fisher_nonsymm_1(self):
         fisher_asymm = []
-        for i in xrange(2):
+        for i in range(2):
             fisher_asymm.append([])
-            for j in xrange(3):
+            for j in range(3):
                 fisher_asymm[i].append(0.0)
         assert_raises( ValueError, fm.fisher_matrix, fisher_matrix=fisher_asymm )
     
@@ -198,10 +198,10 @@ class test_fisher_init():
       
     def test_init_from_python(self):
         matrix = np.identity(10)
-        for i in xrange(10):
+        for i in range(10):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(10) ] 
-        fiducial = [ float(i) for i in xrange(10) ]
+        param_names_latex = [ 'm'+str(i) for i in range(10) ] 
+        fiducial = [ float(i) for i in range(10) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         assert fisher_1.fisher_cutoff == 1e-09
         assert np.allclose( fisher_1.fisher_matrix, matrix )
@@ -253,10 +253,10 @@ class test_fisher_init():
         
     def test_init_from_python_only_fisher(self):
         matrix = np.identity(10)
-        for i in xrange(10):
+        for i in range(10):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(10) ] 
-        fiducial = [ float(i) for i in xrange(10) ]
+        param_names_latex = [ 'm'+str(i) for i in range(10) ] 
+        fiducial = [ float(i) for i in range(10) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         # after calling init all the objects of the class have to be initialized properly:
         assert fisher_1.fisher_cutoff == 1e-09
@@ -273,29 +273,29 @@ class test_fisher_init():
 
     def test_init_from_python_invalid_param_names(self):
         matrix = np.identity(10)
-        for i in xrange(10):
+        for i in range(10):
             matrix[i,i] = i+1
-        param_names = [ 'q'+str(i) for i in xrange(9) ]     
-        param_names_latex = [ 'm'+str(i) for i in xrange(10) ] 
-        fiducial = [ float(i) for i in xrange(10) ]
+        param_names = [ 'q'+str(i) for i in range(9) ]     
+        param_names_latex = [ 'm'+str(i) for i in range(10) ] 
+        fiducial = [ float(i) for i in range(10) ]
         assert_raises( ValueError, fm.fisher_matrix, fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
     
     def test_init_from_python_invalid_param_names_latex(self):
         matrix = np.identity(10)
-        for i in xrange(10):
+        for i in range(10):
             matrix[i,i] = i+1
-        param_names = [ 'q'+str(i) for i in xrange(10) ]     
-        param_names_latex = [ 'm'+str(i) for i in xrange(9) ] 
-        fiducial = [ float(i) for i in xrange(10) ]
+        param_names = [ 'q'+str(i) for i in range(10) ]     
+        param_names_latex = [ 'm'+str(i) for i in range(9) ] 
+        fiducial = [ float(i) for i in range(10) ]
         assert_raises( ValueError, fm.fisher_matrix, fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
     
     def test_init_from_python_invalid_fiducial(self):
         matrix = np.identity(10)
-        for i in xrange(10):
+        for i in range(10):
             matrix[i,i] = i+1
-        param_names = [ 'q'+str(i) for i in xrange(10) ]     
-        param_names_latex = [ 'm'+str(i) for i in xrange(10) ] 
-        fiducial = [ float(i) for i in xrange(9) ]
+        param_names = [ 'q'+str(i) for i in range(10) ]     
+        param_names_latex = [ 'm'+str(i) for i in range(10) ] 
+        fiducial = [ float(i) for i in range(9) ]
         assert_raises( ValueError, fm.fisher_matrix, fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
          
 # ***************************************************************************************
@@ -304,11 +304,11 @@ class test_fisher_load_paramnames_from_file():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_load_paramnames_from_file.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_load_paramnames_from_file.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_load_paramnames_from_file.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_load_paramnames_from_file.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -316,10 +316,10 @@ class test_fisher_load_paramnames_from_file():
     # test the loading of the parameter names from file:
     def test_load_paramnames_from_file_1(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_1.paramnames')
         # test if everything is properly initialized:
@@ -329,10 +329,10 @@ class test_fisher_load_paramnames_from_file():
 
     def test_load_paramnames_from_file_2(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_2.paramnames')
         # test if everything is properly initialized:
@@ -342,10 +342,10 @@ class test_fisher_load_paramnames_from_file():
 
     def test_load_paramnames_from_file_3(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_3.paramnames')
         # test if everything is properly initialized:
@@ -355,10 +355,10 @@ class test_fisher_load_paramnames_from_file():
         
     def test_load_paramnames_from_file_4(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         fisher_1.load_paramnames_from_file( file_name=test_input+'/dummy_paramnames_4.paramnames')
         # test if everything is properly initialized:
@@ -368,10 +368,10 @@ class test_fisher_load_paramnames_from_file():
     
     def test_load_paramnames_from_file_invalid_num_params(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix )
         assert_raises( ValueError, fisher_1.load_paramnames_from_file, file_name=test_input+'/dummy_paramnames_5.paramnames' )
 
@@ -381,11 +381,11 @@ class test_fisher_save_paramnames_to_file():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_save_paramnames_to_file.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_save_paramnames_to_file.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_save_paramnames_to_file.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_save_paramnames_to_file.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -393,10 +393,10 @@ class test_fisher_save_paramnames_to_file():
     # test the loading of the parameter names from file:
     def test_fisher_save_paramnames_to_file_1(self):
         matrix = np.identity(5)
-        for i in xrange(5):
+        for i in range(5):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(5) ] 
-        fiducial = [ float(i) for i in xrange(5) ]
+        param_names_latex = [ 'm'+str(i) for i in range(5) ] 
+        fiducial = [ float(i) for i in range(5) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         fisher_1.save_paramnames_to_file(file_name=test_output+'/dummy_paramnames_out.paramnames')
         fisher_1.indir = './dont_exist'
@@ -409,11 +409,11 @@ class test_save_to_file():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_save_to_file.setup_class() ----------')
+        print(color_print.header(__name__+': test_save_to_file.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_save_to_file.teardown_class() -------')
+        print(color_print.bold(__name__+': test_save_to_file.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -439,11 +439,11 @@ class test_fisher_overload_operations():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_overload_operations.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_overload_operations.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_overload_operations.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_overload_operations.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -451,10 +451,10 @@ class test_fisher_overload_operations():
     # test the fisher matrix addition:
     def test_add_same_params(self):
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         fisher_2 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         fisher_3 = fisher_1+fisher_2
@@ -471,11 +471,11 @@ class test_fisher_overload_operations():
     # test the loading of the parameter names from file:
     def test_add_different_fiducial(self):
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial_1 = [ float(i) for i in xrange(3) ]
-        fiducial_2 = [ float(i+1) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial_1 = [ float(i) for i in range(3) ]
+        fiducial_2 = [ float(i+1) for i in range(3) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial_1 )
         fisher_2 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial_2 )
         
@@ -483,11 +483,11 @@ class test_fisher_overload_operations():
     
     def test_add_different_params(self):
         matrix = np.identity(2)
-        for i in xrange(2):
+        for i in range(2):
             matrix[i,i] = i+1
-        param_names_1 = [ 'm'+str(i) for i in xrange(2) ] 
-        param_names_2 = [ 'b'+str(i) for i in xrange(2) ] 
-        fiducial = [ float(i) for i in xrange(2) ]
+        param_names_1 = [ 'm'+str(i) for i in range(2) ] 
+        param_names_2 = [ 'b'+str(i) for i in range(2) ] 
+        fiducial = [ float(i) for i in range(2) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names = param_names_1, fiducial=fiducial )
         fisher_2 = fm.fisher_matrix( fisher_matrix=matrix, param_names = param_names_2, fiducial=fiducial )
         fisher_3 = fisher_1+fisher_2
@@ -500,27 +500,27 @@ class test_fisher_overload_operations():
         
     def test_equality(self):
         matrix = np.identity(2)
-        for i in xrange(2):
+        for i in range(2):
             matrix[i,i] = i+1
-        param_names = [ 'm'+str(i) for i in xrange(2) ] 
-        fiducial = [ float(i) for i in xrange(2) ]
+        param_names = [ 'm'+str(i) for i in range(2) ] 
+        fiducial = [ float(i) for i in range(2) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names = param_names, fiducial=fiducial )
         
         assert fisher_1 != [0.0]
     
     def test_equality_except(self):
         matrix = np.identity(2)
-        for i in xrange(2):
+        for i in range(2):
             matrix[i,i] = i+1
-        param_names = [ 'm'+str(i) for i in xrange(2) ] 
-        fiducial = [ float(i) for i in xrange(2) ]
+        param_names = [ 'm'+str(i) for i in range(2) ] 
+        fiducial = [ float(i) for i in range(2) ]
         fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names = param_names, fiducial=fiducial )
         
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         fisher_2 = fm.fisher_matrix( fisher_matrix=matrix, param_names = param_names, fiducial=fiducial )
         
         assert fisher_1 != fisher_2
@@ -531,16 +531,16 @@ class test_fisher_std_operations():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_load_paramnames_from_file.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_load_paramnames_from_file.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_load_paramnames_from_file.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_load_paramnames_from_file.teardown_class() -------'))
 
     def setup(self):
         matrix = np.identity(3)
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         pass
     
@@ -562,16 +562,16 @@ class test_fisher_setters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_fisher_setters.setup_class() ----------')
+        print(color_print.header(__name__+': test_fisher_setters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_fisher_setters.teardown_class() -------')
+        print(color_print.bold(__name__+': test_fisher_setters.teardown_class() -------'))
 
     def setup(self):
         matrix = np.identity(3)
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         pass
     
@@ -594,30 +594,30 @@ class test_fisher_setters():
         assert_raises( ValueError, self.fisher_1.set_fisher_matrix, fisher_matrix=matrix )
         
     def test_set_param_names_illegal(self):
-        list = [ 'm'+str(i) for i in xrange(4) ] 
+        list = [ 'm'+str(i) for i in range(4) ] 
         assert_raises( ValueError, self.fisher_1.set_param_names, list )
     
     def test_set_param_names(self):
-        list = [ 'new'+str(i) for i in xrange(3) ] 
+        list = [ 'new'+str(i) for i in range(3) ] 
         self.fisher_1.set_param_names(list)
         assert self.fisher_1.param_names == ['new0', 'new1', 'new2']
         assert self.fisher_1.param_names == self.fisher_1.param_names_latex
     
     def test_set_param_names_latex_illegal(self):
-        list = [ 'm'+str(i) for i in xrange(4) ] 
+        list = [ 'm'+str(i) for i in range(4) ] 
         assert_raises( ValueError, self.fisher_1.set_param_names_latex, list )
     
     def test_set_param_names_latex(self):
-        list = [ 'new'+str(i) for i in xrange(3) ] 
+        list = [ 'new'+str(i) for i in range(3) ] 
         self.fisher_1.set_param_names_latex(list)
         assert self.fisher_1.param_names_latex == ['new0', 'new1', 'new2']
     
     def test_set_fiducial_illegal(self):
-        fiducial = [ float(i) for i in xrange(4) ]
+        fiducial = [ float(i) for i in range(4) ]
         assert_raises( ValueError, self.fisher_1.set_fiducial, fiducial )
     
     def test_set_fiducial(self):
-        fiducial = [ float(i+2) for i in xrange(3) ]
+        fiducial = [ float(i+2) for i in range(3) ]
         self.fisher_1.set_fiducial(fiducial)
         assert np.allclose( self.fisher_1.param_fiducial, [2.0,3.0,4.0] )
         

--- a/python/cosmicfish_pylib_test/test_fisher_operations.py
+++ b/python/cosmicfish_pylib_test/test_fisher_operations.py
@@ -40,19 +40,19 @@ class test_eliminate_columns_rows():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_eliminate_columns_rows.setup_class() ----------')
+        print(color_print.header( __name__+': test_eliminate_columns_rows.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_eliminate_columns_rows.teardown_class() -------')
+        print(color_print.bold( __name__+': test_eliminate_columns_rows.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(4)
-        for i in xrange(4):
+        for i in range(4):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i+1) for i in xrange(4) ] 
-        fiducial = [ float(i) for i in xrange(4) ]
+        param_names_latex = [ 'm'+str(i+1) for i in range(4) ] 
+        fiducial = [ float(i) for i in range(4) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
 
@@ -78,19 +78,19 @@ class test_eliminate_parameters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_eliminate_parameters.setup_class() ----------')
+        print(color_print.header( __name__+': test_eliminate_parameters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_eliminate_parameters.teardown_class() -------')
+        print(color_print.bold( __name__+': test_eliminate_parameters.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
 
@@ -119,19 +119,19 @@ class test_reshuffle():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_reshuffle.setup_class() ----------')
+        print(color_print.header( __name__+': test_reshuffle.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_reshuffle.teardown_class() -------')
+        print(color_print.bold( __name__+': test_reshuffle.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         
@@ -160,19 +160,19 @@ class test_marginalise():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_marginalise.setup_class() ----------')
+        print(color_print.header( __name__+': test_marginalise.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_marginalise.teardown_class() -------')
+        print(color_print.bold( __name__+': test_marginalise.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         
@@ -201,19 +201,19 @@ class test_marginalise_over():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_marginalise_over.setup_class() ----------')
+        print(color_print.header( __name__+': test_marginalise_over.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_marginalise_over.teardown_class() -------')
+        print(color_print.bold( __name__+': test_marginalise_over.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         
@@ -242,19 +242,19 @@ class test_information_gain():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_information_gain.setup_class() ----------')
+        print(color_print.header( __name__+': test_information_gain.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_information_gain.teardown_class() -------')
+        print(color_print.bold( __name__+': test_information_gain.teardown_class() -------'))
 
     def setup(self):
         # generate the Fisher matrix. In this case a simple diagonal matrix.
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
-        param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-        fiducial = [ float(i) for i in xrange(3) ]
+        param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+        fiducial = [ float(i) for i in range(3) ]
         # initialize the Fisher type:
         self.fisher_1 = fm.fisher_matrix( fisher_matrix=1.0*matrix, param_names_latex=param_names_latex, fiducial=fiducial )
         self.fisher_2 = fm.fisher_matrix( fisher_matrix=10.0*matrix, param_names_latex=param_names_latex, fiducial=fiducial )

--- a/python/cosmicfish_pylib_test/test_fisher_plot.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot.py
@@ -41,11 +41,11 @@ class test_setup():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_setup.setup_class() ----------')
+        print(color_print.header(__name__+': test_setup.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_setup.teardown_class() -------')
+        print(color_print.bold(__name__+': test_setup.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -53,12 +53,12 @@ class test_setup():
         num_param = 6
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -103,11 +103,11 @@ class test_utilities():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_utilities.setup_class() ----------')
+        print(color_print.header(__name__+': test_utilities.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_utilities.teardown_class() -------')
+        print(color_print.bold(__name__+': test_utilities.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -115,12 +115,12 @@ class test_utilities():
         num_param = 6
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -151,11 +151,11 @@ class test_plot1D():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot1D.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot1D.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot1D.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot1D.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -163,12 +163,12 @@ class test_plot1D():
         num_param = 6
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -288,11 +288,11 @@ class test_plot2D():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot2D.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot2D.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot2D.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot2D.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -300,12 +300,12 @@ class test_plot2D():
         num_param = 3
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -391,11 +391,11 @@ class test_plot3D():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot3D.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot3D.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot3D.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot3D.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -403,12 +403,12 @@ class test_plot3D():
         num_param = 4
         num_fish  = 1
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -444,11 +444,11 @@ class test_plot_tri():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot_tri.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot_tri.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot_tri.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot_tri.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -456,12 +456,12 @@ class test_plot_tri():
         num_param = 4
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -524,7 +524,7 @@ class test_plot_tri():
         test_plotter = fp.CosmicFishPlotter( fishers=self.fisher_list_test )
         test_plotter.new_plot()
         test_plotter.plot_tri(['p1','p2'])
-        for subplot in test_plotter.plot_dict.values():
+        for subplot in list(test_plotter.plot_dict.values()):
             subplot.yaxis.set_label_position('right')
             subplot.xaxis.set_label_position('top')
         test_plotter.set_triplot_dimensions( num_col=2, num_rows=2 )
@@ -533,7 +533,7 @@ class test_plot_tri():
         test_plotter = fp.CosmicFishPlotter( fishers=self.fisher_list_test )
         test_plotter.new_plot()
         test_plotter.plot_tri(['p1','p2'])
-        for subplot in test_plotter.plot_dict.values():
+        for subplot in list(test_plotter.plot_dict.values()):
             subplot.yaxis.set_label_position('left')
             subplot.xaxis.set_label_position('bottom')
         test_plotter.set_triplot_dimensions( num_col=2, num_rows=2 )
@@ -577,11 +577,11 @@ class test_plot_mixed():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot_mixed.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot_mixed.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot_mixed.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot_mixed.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -589,12 +589,12 @@ class test_plot_mixed():
         num_param = 4
         num_fish  = 3
         matrix = np.identity(num_param)
-        for j in xrange(num_fish):
-            for i in xrange(num_param):
+        for j in range(num_fish):
+            for i in range(num_param):
                 #matrix[i,i] = i+j+1
                 matrix[i,i] = (i+1)/float(j+1)
-            param_names_latex = [ 'm'+str(i) for i in xrange(num_param) ] 
-            fiducial = [ float(i) for i in xrange(num_param) ]
+            param_names_latex = [ 'm'+str(i) for i in range(num_param) ] 
+            fiducial = [ float(i) for i in range(num_param) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -617,11 +617,11 @@ class test_plot_realistic():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot_realistic.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot_realistic.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot_realistic.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot_realistic.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
@@ -681,7 +681,7 @@ class test_plot_realistic():
     
     def test_init_plot_tri_2(self):
         # do spectral protection a couple of times:
-        for i in xrange(4):
+        for i in range(4):
             fish = copy.deepcopy( self.fisher_list_test.get_fisher_list()[-1] )
             fish.protect_degenerate( cache=True )
             fish.name = str(i+1)

--- a/python/cosmicfish_pylib_test/test_fisher_plot_analysis.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot_analysis.py
@@ -39,21 +39,21 @@ class test_class_getters():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_class_getters.setup_class() ----------')
+        print(color_print.header(__name__+': test_class_getters.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_class_getters.teardown_class() -------')
+        print(color_print.bold(__name__+': test_class_getters.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -105,11 +105,11 @@ class test_init():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_init.setup_class() ----------')
+        print(color_print.header(__name__+': test_init.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_init.teardown_class() -------')
+        print(color_print.bold(__name__+': test_init.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -121,12 +121,12 @@ class test_init():
         # create the list of Fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -139,12 +139,12 @@ class test_init():
         # create the list of Fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -161,7 +161,7 @@ class test_init():
         assert_raises( ValueError, fisher_list_test.add_fisher_matrix, [0.0] )
         # check second raise:
         matrix = np.identity(3)
-        for i in xrange(3):
+        for i in range(3):
             matrix[i,i] = i+1
         fisher = fm.fisher_matrix( fisher_matrix=matrix )
         # add a fisher without a name:
@@ -212,22 +212,22 @@ class test_get_fisher_matrix():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_get_fisher_matrix.setup_class() ----------')
+        print(color_print.header(__name__+': test_get_fisher_matrix.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_get_fisher_matrix.teardown_class() -------')
+        print(color_print.bold(__name__+': test_get_fisher_matrix.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -249,22 +249,22 @@ class test_delete_fisher_matrix():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_delete_fisher_matrix.setup_class() ----------')
+        print(color_print.header(__name__+': test_delete_fisher_matrix.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_delete_fisher_matrix.teardown_class() -------')
+        print(color_print.bold(__name__+': test_delete_fisher_matrix.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -285,22 +285,22 @@ class test_get_parameter_list():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_get_parameter_list.setup_class() ----------')
+        print(color_print.header(__name__+': test_get_parameter_list.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_get_parameter_list.teardown_class() -------')
+        print(color_print.bold(__name__+': test_get_parameter_list.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -321,22 +321,22 @@ class test_get_parameter_latex_names():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_get_parameter_latex_names.setup_class() ----------')
+        print(color_print.header(__name__+': test_get_parameter_latex_names.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_get_parameter_latex_names.teardown_class() -------')
+        print(color_print.bold(__name__+': test_get_parameter_latex_names.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i+j) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i+j) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -357,22 +357,22 @@ class test_reshuffle():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_reshuffle.setup_class() ----------')
+        print(color_print.header(__name__+': test_reshuffle.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_reshuffle.teardown_class() -------')
+        print(color_print.bold(__name__+': test_reshuffle.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -394,22 +394,22 @@ class test_marginalise():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_marginalise.setup_class() ----------')
+        print(color_print.header(__name__+': test_marginalise.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_marginalise.teardown_class() -------')
+        print(color_print.bold(__name__+': test_marginalise.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -431,22 +431,22 @@ class test_plot_range():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_plot_range.setup_class() ----------')
+        print(color_print.header(__name__+': test_plot_range.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_plot_range.teardown_class() -------')
+        print(color_print.bold(__name__+': test_plot_range.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -480,22 +480,22 @@ class test_compute_gaussian():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_compute_gaussian.setup_class() ----------')
+        print(color_print.header(__name__+': test_compute_gaussian.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_compute_gaussian.teardown_class() -------')
+        print(color_print.bold(__name__+': test_compute_gaussian.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -508,22 +508,22 @@ class test_compute_gaussian():
         
         results_1 = self.fisher_list_test.compute_gaussian(num_points=10)
         
-        assert results_1.keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
-        assert results_1.values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
+        assert list(results_1.keys()) == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
+        assert list(results_1.values())[0].keys() == ['fisher2', 'fisher3', 'fisher1']
         
     def test_compute_gaussian_one_param(self):
         
         results_1 = self.fisher_list_test.compute_gaussian( params='pa1', num_points=10)
         
-        assert results_1.keys() == ['pa1']
-        assert results_1.values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
+        assert list(results_1.keys()) == ['pa1']
+        assert list(results_1.values())[0].keys() == ['fisher2', 'fisher3', 'fisher1']
         
     def test_compute_gaussian_one_fisher(self):
         
         results_1 = self.fisher_list_test.compute_gaussian( names='fisher1', num_points=10)
         
-        assert results_1.keys() == ['pa0', 'pa1', 'pa2']
-        assert results_1.values()[0].keys() == ['fisher1']
+        assert list(results_1.keys()) == ['pa0', 'pa1', 'pa2']
+        assert list(results_1.values())[0].keys() == ['fisher1']
 
     def test_compute_gaussian_without_nice(self):
         
@@ -539,22 +539,22 @@ class test_compute_compute_ellipse():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_compute_compute_ellipse.setup_class() ----------')
+        print(color_print.header(__name__+': test_compute_compute_ellipse.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_compute_compute_ellipse.teardown_class() -------')
+        print(color_print.bold(__name__+': test_compute_compute_ellipse.teardown_class() -------'))
 
     def setup(self):
         # create a list of fisher matrices:
         fisher_list = []
         matrix = np.identity(3)
-        for j in xrange(3):
-            for i in xrange(3):
+        for j in range(3):
+            for i in range(3):
                 matrix[i,i] = i+j+1
-            param_names = [ 'pa'+str(i+j) for i in xrange(3) ] 
-            param_names_latex = [ 'm'+str(i) for i in xrange(3) ] 
-            fiducial = [ float(i) for i in xrange(3) ]
+            param_names = [ 'pa'+str(i+j) for i in range(3) ] 
+            param_names_latex = [ 'm'+str(i) for i in range(3) ] 
+            fiducial = [ float(i) for i in range(3) ]
             fisher = fm.fisher_matrix( fisher_matrix=matrix, param_names=param_names, param_names_latex=param_names_latex, fiducial=fiducial )
             fisher.name = 'fisher'+str(j+1)
             fisher_list.append( fisher )
@@ -567,33 +567,33 @@ class test_compute_compute_ellipse():
         
         results_1 = self.fisher_list_test.compute_ellipse(num_points=10)
         
-        assert results_1.keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
-        assert results_1.values()[0].keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
-        assert results_1.values()[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
+        assert list(results_1.keys()) == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
+        assert list(results_1.values())[0].keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
+        assert list(results_1.values())[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
         
     def test_compute_ellipse_one_param_multiple_param(self):
         
         results_1 = self.fisher_list_test.compute_ellipse( params1='pa1', num_points=10)
         
-        assert results_1.keys() == ['pa1']
-        assert results_1.values()[0].keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
-        assert results_1.values()[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
+        assert list(results_1.keys()) == ['pa1']
+        assert list(results_1.values())[0].keys() == ['pa0', 'pa1', 'pa2', 'pa3', 'pa4']
+        assert list(results_1.values())[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
     
     def test_compute_ellipse_one_param_one_param(self):
         
         results_1 = self.fisher_list_test.compute_ellipse( params1='pa1',params2='pa2', num_points=10)
         
-        assert results_1.keys() == ['pa1']
-        assert results_1.values()[0].keys() == ['pa2']
-        assert results_1.values()[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
+        assert list(results_1.keys()) == ['pa1']
+        assert list(results_1.values())[0].keys() == ['pa2']
+        assert list(results_1.values())[0].values()[0].keys() == ['fisher2', 'fisher3', 'fisher1']
         
     def test_compute_ellipse_one_fisher(self):
         
         results_1 = self.fisher_list_test.compute_ellipse( names='fisher1', num_points=10)
         
-        assert results_1.keys() == ['pa0', 'pa1', 'pa2']
-        assert results_1.values()[0].keys() == ['pa0', 'pa1', 'pa2']
-        assert results_1.values()[0].values()[0].keys() == ['fisher1']
+        assert list(results_1.keys()) == ['pa0', 'pa1', 'pa2']
+        assert list(results_1.values())[0].keys() == ['pa0', 'pa1', 'pa2']
+        assert list(results_1.values())[0].values()[0].keys() == ['fisher1']
 
         
 # ***************************************************************************************

--- a/python/cosmicfish_pylib_test/test_fisher_plot_settings.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot_settings.py
@@ -36,11 +36,11 @@ class test_init():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_init.setup_class() ----------')
+        print(color_print.header( __name__+': test_init.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_init.teardown_class() -------')
+        print(color_print.bold( __name__+': test_init.teardown_class() -------'))
 
     def test_init_settings_default(self):
         settings = fps.CosmicFish_PlotSettings()
@@ -63,11 +63,11 @@ class test_update():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header( __name__+': test_update.setup_class() ----------')
+        print(color_print.header( __name__+': test_update.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold( __name__+': test_update.teardown_class() -------')
+        print(color_print.bold( __name__+': test_update.teardown_class() -------'))
 
     def test_update_dict(self):
         settings = fps.CosmicFish_PlotSettings()

--- a/python/cosmicfish_pylib_test/test_utilities.py
+++ b/python/cosmicfish_pylib_test/test_utilities.py
@@ -38,11 +38,11 @@ class test_nice_number():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_nice_number.setup_class() ----------')
+        print(color_print.header(__name__+': test_nice_number.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_nice_number.teardown_class() -------')
+        print(color_print.bold(__name__+': test_nice_number.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -71,11 +71,11 @@ class test_significant_digits():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_nice_number.setup_class() ----------')
+        print(color_print.header(__name__+': test_nice_number.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_nice_number.teardown_class() -------')
+        print(color_print.bold(__name__+': test_nice_number.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -134,11 +134,11 @@ class test_make_list():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_make_list.setup_class() ----------')
+        print(color_print.header(__name__+': test_make_list.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_make_list.teardown_class() -------')
+        print(color_print.bold(__name__+': test_make_list.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -162,11 +162,11 @@ class test_print_table():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_print_table.setup_class() ----------')
+        print(color_print.header(__name__+': test_print_table.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_print_table.teardown_class() -------')
+        print(color_print.bold(__name__+': test_print_table.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -183,11 +183,11 @@ class test_confidence_coefficient():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_confidence_coefficient.setup_class() ----------')
+        print(color_print.header(__name__+': test_confidence_coefficient.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_confidence_coefficient.teardown_class() -------')
+        print(color_print.bold(__name__+': test_confidence_coefficient.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -204,11 +204,11 @@ class test_num_to_mant_exp():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_num_to_mant_exp.setup_class() ----------')
+        print(color_print.header(__name__+': test_num_to_mant_exp.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_num_to_mant_exp.teardown_class() -------')
+        print(color_print.bold(__name__+': test_num_to_mant_exp.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -225,11 +225,11 @@ class test_grouper():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_grouper.setup_class() ----------')
+        print(color_print.header(__name__+': test_grouper.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_grouper.teardown_class() -------')
+        print(color_print.bold(__name__+': test_grouper.teardown_class() -------'))
 
     def setup(self):
         pass
@@ -249,11 +249,11 @@ class test_CosmicFish_write_header():
 
     @classmethod
     def setup_class(cls):
-        print color_print.header(__name__+': test_CosmicFish_write_header.setup_class() ----------')
+        print(color_print.header(__name__+': test_CosmicFish_write_header.setup_class() ----------'))
        
     @classmethod
     def teardown_class(cls):
-        print color_print.bold(__name__+': test_CosmicFish_write_header.teardown_class() -------')
+        print(color_print.bold(__name__+': test_CosmicFish_write_header.teardown_class() -------'))
 
     def setup(self):
         pass


### PR DESCRIPTION
Seeing as how Python 2 was [deprecated](https://www.python.org/doc/sunset-python-2/) this year, I've made some minimal changes which should hopefully make CosmicFish run under Python 3+ as well.

Note that there's still one last thing that needs to be fixed when running tests:
```python
line 163, in search_fisher_path:
    if CosmicFishPyLib.__feedback__ > 1: print('Trying to import: '+file+' as a Fisher matrix: ', end=' ')
AttributeError: 'method-wrapper' object has no attribute '__feedback__'
```
which *I think* has something to do with the lack of [unbound methods](https://stackoverflow.com/questions/10401935/python-method-wrapper-type) in Python 3, and don't really know how to fix properly.

Other than that, there could be some inadvertent lack of float rounding in the ticks of the plots, which can be easily fixed, a minimal diff example is attached.
[formatting.patch](https://github.com/CosmicFish/CosmicFish/files/4187331/formatting.txt)
