### PR TITLE
Implementation of `show_best_fit`

### DIFF
--- a/python/cosmicfish_pylib/fisher_plot.py
+++ b/python/cosmicfish_pylib/fisher_plot.py
@@ -491,6 +491,7 @@ class CosmicFishPlotter():
         filling_alpha = self.setting_setter('D1_alpha', **kwargs)
         ylabel_right = self.setting_setter('D1_ylabel_right', **kwargs)
         xlabel_up = self.setting_setter('D1_xlabel_up', **kwargs)
+        show_best_fit = self.setting_setter('D1_show_best_fit', **kwargs)
         # do the plotting:
         if filled:
             for i,confl in enumerate(confidence_level):
@@ -511,6 +512,16 @@ class CosmicFishPlotter():
                           linestyle = self.bind_linestyle[name],
                           linewidth = linewidth, 
                           label     = self.bind_labels[name] )
+        if show_best_fit:
+            # go over the Fisher matrices and plot fiducials:
+            for name, fisher in zip(names, self.plot_fishers.get_fisher_matrix(names)):
+                # note: the vline goes from 0 to 2 because the non-normalized one has a range [0,1] anyway
+                subplot.vlines(
+                    fisher.get_fiducial(param),
+                    0, 2.0,
+                    linestyle = self.bind_linestyle[name],
+                    linewidth = linewidth
+                )
         # set the plot range:
         x_limits = self.plot_fishers.compute_plot_range(params=param, confidence_level=max(confidence_level), names=names_temp, nice=nice)[param]
         subplot.set_xlim( x_limits )
@@ -608,6 +619,7 @@ class CosmicFishPlotter():
         filling_alpha = self.setting_setter('D2_alphas', **kwargs)
         ylabel_right = self.setting_setter('D2_ylabel_right', **kwargs)
         xlabel_up = self.setting_setter('D2_xlabel_up', **kwargs)
+        show_best_fit = self.setting_setter('D2_show_best_fit', **kwargs)
         # get the data:
         for j,confidence in enumerate(confidence_level):
             # get the data from the fisher_plot_analysis:
@@ -635,6 +647,21 @@ class CosmicFishPlotter():
         ranges = self.plot_fishers.compute_plot_range(params=[param1,param2], confidence_level=max(confidence_level), names=names_temp, nice=nice)
         subplot.set_xlim( ranges[param1] )
         subplot.set_ylim( ranges[param2] )
+        if show_best_fit:
+            # go over the Fisher matrices and plot fiducials:
+            for name, fisher in zip(names, self.plot_fishers.get_fisher_matrix(names)):
+                subplot.vlines(
+                    fisher.get_fiducial(param1),
+                    ranges[param2][0], ranges[param2][1],
+                    linestyle = self.bind_linestyle[name],
+                    linewidth = linewidth
+                )
+                subplot.hlines(
+                    fisher.get_fiducial(param2),
+                    ranges[param1][0], ranges[param1][1],
+                    linestyle = self.bind_linestyle[name],
+                    linewidth = linewidth
+                )
         # set the ticks and ticks labels:
         if show_x_ticks:
             subplot.set_xticks( np.linspace(ranges[param1][0], ranges[param1][1], number_x_ticks)  )

--- a/python/cosmicfish_pylib/fisher_plot_settings.py
+++ b/python/cosmicfish_pylib/fisher_plot_settings.py
@@ -81,7 +81,7 @@ class CosmicFish_PlotSettings():
     :ivar D1_norm_prob_label: y axis label to use when P is normalized. Default: u'$P$'  
     :ivar D1_main_fontsize: main fontsize for the 1D plot. Default: 10.0   
     :ivar D1_secondary_fontsize: secondary fontsize for the 1D plot. Default:
-    :ivar D1_show_best_fit: show a vertical line on the fiducial. NOT YET IMPLEMENTED. Default: False
+    :ivar D1_show_best_fit: show a vertical line on the fiducial. Default: False
 
     :ivar D2_confidence_levels: list with confidence levels for the 2D plot. Default: [ 0.95, 0.68 ]      
     :ivar D2_num_points: number of points per line in the plot. Default: 100 
@@ -105,7 +105,7 @@ class CosmicFish_PlotSettings():
     :ivar D2_y_label_rotation: rotation of the y axis label. Default: 90 
     :ivar D2_main_fontsize: main fontsize. Default: 10.0
     :ivar D2_secondary_fontsize: secondary fontsize. Default: 9.0
-    :ivar D2_show_best_fit: show a vertical line on the fiducial. NOT YET IMPLEMENTED. Default: False
+    :ivar D2_show_best_fit: show an intersecting line on the fiducial. Default: False
         
     :ivar num_plots_per_line: number of plots per line. Used in all plots but triangulars. Default: 3
     :ivar figure_width: width of the image in cm. Default: paper_width


### PR DESCRIPTION
I've implemented both `D1_show_best_fit` and `D2_show_best_fit` in `CosmicFishPlotter`, works in both Python 2 and 3.
The lines have the same styling as their respective histograms/ellipses, except the color, which is set to the default (black) since it's a bit hard to see a same-colored line with certain plot settings.
I've also attached some examples below.

[1D plot example](https://github.com/CosmicFish/CosmicFish/files/4204932/D1_show_best_fit.pdf)
[2D plot example](https://github.com/CosmicFish/CosmicFish/files/4204933/D2_show_best_fit.pdf)
[Combined](https://github.com/CosmicFish/CosmicFish/files/4204952/combined.pdf)

