### PR TITLE
Added option `D1_extra_vlines`

### DIFF
--- a/python/cosmicfish_pylib/fisher_plot.py
+++ b/python/cosmicfish_pylib/fisher_plot.py
@@ -491,6 +491,7 @@ class CosmicFishPlotter():
         filling_alpha = self.setting_setter('D1_alpha', **kwargs)
         ylabel_right = self.setting_setter('D1_ylabel_right', **kwargs)
         xlabel_up = self.setting_setter('D1_xlabel_up', **kwargs)
+        extra_vlines = self.setting_setter('D1_extra_vlines', **kwargs)
         # do the plotting:
         if filled:
             for i,confl in enumerate(confidence_level):
@@ -515,6 +516,22 @@ class CosmicFishPlotter():
         x_limits = self.plot_fishers.compute_plot_range(params=param, confidence_level=max(confidence_level), names=names_temp, nice=nice)[param]
         subplot.set_xlim( x_limits )
         subplot.set_ylim( [0.0, 1.05] )
+        if extra_vlines is not None and isinstance(extra_vlines, dict):
+            if param in extra_vlines:
+                if min(x_limits) <= extra_vlines[param] <= max(x_limits):
+                    extra_vlines_kwargs = extra_vlines[None] if None in extra_vlines else {}
+                    subplot.vlines(
+                        extra_vlines[param],
+                        0, 2.0,
+                        **extra_vlines_kwargs
+                    )
+                else:
+                    # maybe print that the requested vline lies outside the xrange?
+                    pass
+            else:
+                # print a warning about a missing key or something
+                pass
+
         # set the ticks and ticks labels:
         if show_x_ticks:
             subplot.set_xticks( np.linspace(x_limits[0], x_limits[1], number_x_ticks)  )

--- a/python/cosmicfish_pylib/fisher_plot_settings.py
+++ b/python/cosmicfish_pylib/fisher_plot_settings.py
@@ -186,6 +186,7 @@ class CosmicFish_PlotSettings():
         self.D1_main_fontsize        = 10.0                
         self.D1_secondary_fontsize   = 9.0                 
         self.D1_show_best_fit        = False               
+        self.D1_extra_vlines         = None
     
         # options for 2D plots:
         self.D2_confidence_levels    = [ 0.95, 0.68 ]      
@@ -329,6 +330,7 @@ __accepted_settings__=[
     'D1_main_fontsize',
     'D1_secondary_fontsize',
     'D1_show_best_fit',
+    'D1_extra_vlines',
     'D2_confidence_levels',
     'D2_num_points',
     'D2_line_thickness',

--- a/python/cosmicfish_pylib_test/test_fisher_plot.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot.py
@@ -282,7 +282,7 @@ class test_plot1D():
         test_plotter.export(plot_dump+'test_plot_1D_options_12.pdf')
         test_plotter.close_plot()
 
-        # test for extra_vlines
+        # test for extra_vlines (single)
         pnames = self.fisher_list_test.get_fisher_list()[0].get_param_names()
         pvalues = self.fisher_list_test.get_fisher_list()[0].get_param_fiducial()
         extra_vlines = {pname : pvalue * 1.5 for pname, pvalue in zip(pnames, pvalues)}
@@ -299,6 +299,36 @@ class test_plot1D():
         test_plotter.plot1D('p2')
         test_plotter.export(plot_dump+'test_plot_1D_options_13.pdf')
         test_plotter.close_plot()
+
+        # test for extra_vlines (multiple)
+        extra_vlines = [
+            {pname : pvalue * (1 + index / 3.) for pname, pvalue in zip(pnames, pvalues)} for index in range(3)
+        ]
+        extra_vlines[0][None] = {
+            'linestyle' : '--',
+            'color' : 'green',
+            'linewidth' : 2,
+        }
+        extra_vlines[1][None] = {
+            'linestyle' : ':',
+            'color' : 'orange',
+            'linewidth' : 2,
+        }
+        extra_vlines[2][None] = {
+            'linestyle' : '-.',
+            'color' : 'magenta',
+            'linewidth' : 2,
+        }
+
+        test_plotter = fp.CosmicFishPlotter(
+            fishers=self.fisher_list_test,
+            D1_extra_vlines=extra_vlines,
+        )
+        test_plotter.new_plot()
+        test_plotter.plot1D('p2')
+        test_plotter.export(plot_dump+'test_plot_1D_options_14.pdf')
+        test_plotter.close_plot()
+
         
 # ***************************************************************************************
     
@@ -578,6 +608,53 @@ class test_plot_tri():
         test_plotter.new_plot()
         test_plotter.plot_tri(['p1','p2'])
         test_plotter.export(plot_dump+'test_plot_tri_options_10.pdf')
+        test_plotter.close_plot()
+
+        # test for extra_vlines (single)
+        pnames = self.fisher_list_test.get_fisher_list()[0].get_param_names()
+        pvalues = self.fisher_list_test.get_fisher_list()[0].get_param_fiducial()
+        extra_vlines = {pname : pvalue * 1.5 for pname, pvalue in zip(pnames, pvalues)}
+        extra_vlines[None] = {
+            'linestyle' : '--',
+            'color' : 'green',
+            'linewidth' : 3,
+        }
+        test_plotter = fp.CosmicFishPlotter(
+            fishers=self.fisher_list_test,
+            D1_extra_vlines=extra_vlines,
+        )
+        test_plotter.new_plot()
+        test_plotter.plot_tri(['p1','p2'])
+        test_plotter.export(plot_dump+'test_plot_tri_options_11.pdf')
+        test_plotter.close_plot()
+
+        # test for extra_vlines (multiple)
+        extra_vlines = [
+            {pname : pvalue * (1 + index / 3.) for pname, pvalue in zip(pnames, pvalues)} for index in range(3)
+        ]
+        extra_vlines[0][None] = {
+            'linestyle' : '--',
+            'color' : 'green',
+            'linewidth' : 2,
+        }
+        extra_vlines[1][None] = {
+            'linestyle' : ':',
+            'color' : 'orange',
+            'linewidth' : 2,
+        }
+        extra_vlines[2][None] = {
+            'linestyle' : '-.',
+            'color' : 'magenta',
+            'linewidth' : 2,
+        }
+
+        test_plotter = fp.CosmicFishPlotter(
+            fishers=self.fisher_list_test,
+            D1_extra_vlines=extra_vlines,
+        )
+        test_plotter.new_plot()
+        test_plotter.plot_tri(['p1','p2'])
+        test_plotter.export(plot_dump+'test_plot_tri_options_12.pdf')
         test_plotter.close_plot()
     
     def test_plot_tri_legend(self):

--- a/python/cosmicfish_pylib_test/test_fisher_plot.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot.py
@@ -288,7 +288,7 @@ class test_plot1D():
         extra_vlines = {pname : pvalue * 1.5 for pname, pvalue in zip(pnames, pvalues)}
         extra_vlines[None] = {
             'linestyle' : '--',
-            'color' : 'C2',
+            'color' : 'green',
             'linewidth' : 3,
         }
         test_plotter = fp.CosmicFishPlotter(
@@ -296,7 +296,7 @@ class test_plot1D():
             D1_extra_vlines=extra_vlines,
         )
         test_plotter.new_plot()
-        test_plotter.plot1D(['p2', 'p3'])
+        test_plotter.plot1D('p2')
         test_plotter.export(plot_dump+'test_plot_1D_options_13.pdf')
         test_plotter.close_plot()
         

--- a/python/cosmicfish_pylib_test/test_fisher_plot.py
+++ b/python/cosmicfish_pylib_test/test_fisher_plot.py
@@ -281,6 +281,24 @@ class test_plot1D():
         test_plotter.plot1D('p1')
         test_plotter.export(plot_dump+'test_plot_1D_options_12.pdf')
         test_plotter.close_plot()
+
+        # test for extra_vlines
+        pnames = self.fisher_list_test.get_fisher_list()[0].get_param_names()
+        pvalues = self.fisher_list_test.get_fisher_list()[0].get_param_fiducial()
+        extra_vlines = {pname : pvalue * 1.5 for pname, pvalue in zip(pnames, pvalues)}
+        extra_vlines[None] = {
+            'linestyle' : '--',
+            'color' : 'C2',
+            'linewidth' : 3,
+        }
+        test_plotter = fp.CosmicFishPlotter(
+            fishers=self.fisher_list_test,
+            D1_extra_vlines=extra_vlines,
+        )
+        test_plotter.new_plot()
+        test_plotter.plot1D(['p2', 'p3'])
+        test_plotter.export(plot_dump+'test_plot_1D_options_13.pdf')
+        test_plotter.close_plot()
         
 # ***************************************************************************************
     


### PR DESCRIPTION
Added an option to place multiple extra vertical lines on 1D plots.
The usage pattern is of the form:
```
D1_extra_vlines=[{[PARAMETER] : [VALUE], None : **kwargs}, ...]
```
where `[PARAMETER]` is the name of the parameter, `[VALUE]` is its corresponding value, and `**kwargs` are all of the keyword arguments used in a `matplotlib.axes.Axes.vlines` class, as described [here](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.vlines.html).
Note that one can pass either a `dict` itself, or a list of `dict`s, as shown above.
Also note that `None` is used as a key in the `dict`s to avoid any possible naming collisions with the parameter names themselves, and it's a bit less confusing than using `''` or `""`.

Some examples are attached.
[1D plot](https://github.com/CosmicFish/CosmicFish/files/4313044/test_plot_1D_options_14.pdf)
[triangle plot](https://github.com/CosmicFish/CosmicFish/files/4313043/test_plot_tri_options_12.pdf)

